### PR TITLE
Use RISC Zero BigInt multiplier to accelerate k256 within the zkVM guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.5.2"
-source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?branch=victor/use-risc0-accel#725b3bcb26c3498ca4f2924f9e7f843d4bd3045f"
+source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.2-risc0#8b30304277cfe553b51a78a0e693f48bbb059eb3"
 dependencies = [
  "generic-array",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,12 +119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "bytemuck"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +584,6 @@ name = "k256"
 version = "0.13.1"
 dependencies = [
  "blobby",
- "bytemuck",
  "cfg-if",
  "criterion",
  "ecdsa",
@@ -839,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -881,9 +874,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,11 +298,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+version = "0.5.2"
+source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?branch=victor/use-risc0-accel#725b3bcb26c3498ca4f2924f9e7f843d4bd3045f"
 dependencies = [
  "generic-array",
+ "getrandom",
  "rand_core",
  "subtle",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -578,16 +584,17 @@ name = "k256"
 version = "0.13.1"
 dependencies = [
  "blobby",
+ "bytemuck",
  "cfg-if",
  "criterion",
  "ecdsa",
  "elliptic-curve",
+ "getrandom",
  "hex-literal",
  "num-bigint",
  "num-traits",
  "once_cell",
  "proptest",
- "rand_core",
  "serdect",
  "sha2",
  "sha3",
@@ -824,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -866,9 +873,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,11 +596,13 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "getrandom",
+ "hex",
  "hex-literal",
  "num-bigint",
  "num-traits",
  "once_cell",
  "proptest",
+ "rand_core",
  "serdect",
  "sha2",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,8 +1095,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.6-risc0#e75cafd9f55da196061f6fadf8bc8a86778192b7"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,6 @@ dependencies = [
  "criterion",
  "ecdsa",
  "elliptic-curve",
- "getrandom",
  "hex",
  "hex-literal",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,8 @@ opt-level = 2
 
 [patch.crates-io.crypto-bigint]
 git = "https://github.com/risc0/RustCrypto-crypto-bigint"
-branch = "victor/use-risc0-accel"
+branch = "victor/use-risc0-accel" # DO NOT MERGE: Use a tag instead.
+
+[patch.crates-io.sha2]
+git = "https://github.com/risc0/RustCrypto-hashes"
+tag = "sha2-v0.10.6-risc0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.crypto-bigint]
+git = "https://github.com/risc0/RustCrypto-crypto-bigint"
+branch = "victor/use-risc0-accel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ opt-level = 2
 
 [patch.crates-io.crypto-bigint]
 git = "https://github.com/risc0/RustCrypto-crypto-bigint"
-branch = "victor/use-risc0-accel" # DO NOT MERGE: Use a tag instead.
+tag = "v0.5.2-risc0"
 
 [patch.crates-io.sha2]
 git = "https://github.com/risc0/RustCrypto-hashes"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -31,7 +31,6 @@ signature = { version = "2", optional = true }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
 getrandom = { version = "0.2.9", features = ["custom"] }
-bytemuck = "1.13"
 
 [dev-dependencies]
 blobby = "0.3"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -37,6 +37,7 @@ bytemuck = "1.13"
 blobby = "0.3"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
+hex = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -29,16 +29,22 @@ serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+getrandom = { version = "0.2.9", features = ["custom"] }
+bytemuck = "1.13"
+
 [dev-dependencies]
 blobby = "0.3"
-criterion = "0.4"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
-proptest = "1.1"
 rand_core = { version = "0.6", features = ["getrandom"] }
 sha3 = { version = "0.10", default-features = false }
+
+[target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
+proptest = "1.1"
+criterion = "0.4"
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -29,9 +29,6 @@ serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
 
-[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-getrandom = { version = "0.2.9", features = ["custom"] }
-
 [dev-dependencies]
 blobby = "0.3"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -40,8 +40,11 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 sha3 = { version = "0.10", default-features = false }
 
 [target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
-proptest = "1.1"
-criterion = "0.4"
+criterion = { version = "0.4", features = ["html_reports"] }
+proptest = "1"
+
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
+proptest = { version = "1", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,12 +19,12 @@ rust-version = "1.65"
 
 [dependencies]
 cfg-if = "1.0"
-ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
-hex-literal = { version = "0.4", optional = true }
 
 # optional dependencies
 once_cell = { version = "1.17", optional = true, default-features = false }
+ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
+hex-literal = { version = "0.4", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
@@ -32,7 +32,6 @@ signature = { version = "2", optional = true }
 [dev-dependencies]
 blobby = "0.3"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
-hex = "0.4"
 hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
@@ -45,6 +44,7 @@ proptest = "1"
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["alloc"] }
+hex = "0.4"
 
 [features]
 default = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "schnorr", "std"]

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -19,12 +19,12 @@ rust-version = "1.65"
 
 [dependencies]
 cfg-if = "1.0"
+ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
 elliptic-curve = { version = "0.13", default-features = false, features = ["hazmat", "sec1"] }
+hex-literal = { version = "0.4", optional = true }
 
 # optional dependencies
 once_cell = { version = "1.17", optional = true, default-features = false }
-ecdsa-core = { version = "0.16", package = "ecdsa", optional = true, default-features = false, features = ["der"] }
-hex-literal = { version = "0.4", optional = true }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true }
@@ -32,8 +32,8 @@ signature = { version = "2", optional = true }
 [dev-dependencies]
 blobby = "0.3"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
-hex-literal = "0.4"
 hex = "0.4"
+hex-literal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -22,7 +22,9 @@ cfg_if! {
         use field_impl::FieldElementImpl;
     } else {
         cfg_if! {
-            if #[cfg(target_pointer_width = "32")] {
+            if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
+                use field_8x32_risc0::FieldElement8x32R0 as FieldElementImpl;
+            } else if #[cfg(target_pointer_width = "32")] {
                 use field_10x26::FieldElement10x26 as FieldElementImpl;
             } else if #[cfg(target_pointer_width = "64")] {
                 use field_5x52::FieldElement5x52 as FieldElementImpl;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -366,6 +366,12 @@ impl From<u64> for FieldElement {
     }
 }
 
+impl From<i64> for FieldElement {
+    fn from(k: i64) -> Self {
+        Self(FieldElementImpl::from_i64(k))
+    }
+}
+
 impl PartialEq for FieldElement {
     fn eq(&self, other: &Self) -> bool {
         self.0.ct_eq(&(other.0)).into()

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -5,7 +5,9 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(target_pointer_width = "32")] {
+    if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
+        mod field_8x32_risc0;
+    } else if #[cfg(target_pointer_width = "32")] {
         mod field_10x26;
     } else if #[cfg(target_pointer_width = "64")] {
         mod field_5x52;
@@ -500,6 +502,8 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 mod tests {
     use elliptic_curve::ff::{Field, PrimeField};
     use num_bigint::{BigUint, ToBigUint};
+
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::prelude::*;
 
     use super::FieldElement;
@@ -706,6 +710,7 @@ mod tests {
         let _result = y.is_odd();
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     prop_compose! {
         fn field_element()(bytes in any::<[u8; 32]>()) -> FieldElement {
             let mut res = bytes_to_biguint(&bytes);
@@ -719,6 +724,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     proptest! {
 
         #[test]

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -521,7 +521,6 @@ mod tests {
     use elliptic_curve::ff::{Field, PrimeField};
     use num_bigint::{BigUint, ToBigUint};
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::prelude::*;
 
     use super::FieldElement;
@@ -728,7 +727,6 @@ mod tests {
         let _result = y.is_odd();
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     prop_compose! {
         fn field_element()(bytes in any::<[u8; 32]>()) -> FieldElement {
             let mut res = bytes_to_biguint(&bytes);
@@ -742,8 +740,16 @@ mod tests {
         }
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+    fn config() -> ProptestConfig {
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            ProptestConfig::with_cases(1)
+        } else {
+            ProptestConfig::default()
+        }
+    }
+
     proptest! {
+        #![proptest_config(config())]
 
         #[test]
         fn fuzzy_add(

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -107,6 +107,12 @@ impl FieldElement {
         Self(FieldElementImpl::from_u64(w))
     }
 
+    /// Convert a `i64` to a field element.
+    /// Returned value may be only weakly normalized.
+    pub const fn from_i64(w: i64) -> Self {
+        Self(FieldElementImpl::from_i64(w))
+    }
+
     /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(self) -> FieldBytes {
         self.0.normalize().to_bytes()

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -520,7 +520,6 @@ impl<'a> Product<&'a FieldElement> for FieldElement {
 mod tests {
     use elliptic_curve::ff::{Field, PrimeField};
     use num_bigint::{BigUint, ToBigUint};
-
     use proptest::prelude::*;
 
     use super::FieldElement;

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -150,12 +150,10 @@ impl FieldElement {
     /// Returns 2*self.
     /// Doubles the magnitude.
     pub fn double(&self) -> Self {
-        cfg_if::cfg_if! {
-            if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
-                self.mul_single(2)
-            } else {
-                Self(self.0.add(&(self.0)))
-            }
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            self.mul_single(2)
+        } else {
+            Self(self.0.add(&(self.0)))
         }
     }
 

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -144,7 +144,13 @@ impl FieldElement {
     /// Returns 2*self.
     /// Doubles the magnitude.
     pub fn double(&self) -> Self {
-        Self(self.0.add(&(self.0)))
+        cfg_if::cfg_if! {
+            if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
+                self.mul_single(2)
+            } else {
+                Self(self.0.add(&(self.0)))
+            }
+        }
     }
 
     /// Returns self * rhs mod p

--- a/k256/src/arithmetic/field/field_5x52.rs
+++ b/k256/src/arithmetic/field/field_5x52.rs
@@ -83,6 +83,14 @@ impl FieldElement5x52 {
         Self([w0, w1, 0, 0, 0])
     }
 
+    pub const fn from_i64(val: i64) -> Self {
+        // Compute val_abs = |val|
+        let val_mask = val >> 63;
+        let val_abs = ((val + val_mask) ^ val_mask) as u64;
+
+        Self::from_u64(val_abs).negate(1).normalize_weak()
+    }
+
     /// Returns the SEC1 encoding of this field element.
     pub fn to_bytes(self) -> FieldBytes {
         let mut ret = FieldBytes::default();
@@ -122,7 +130,7 @@ impl FieldElement5x52 {
     }
 
     /// Adds `x * (2^256 - modulus)`.
-    fn add_modulus_correction(&self, x: u64) -> Self {
+    const fn add_modulus_correction(&self, x: u64) -> Self {
         // add (2^256 - modulus) * x to the first limb
         let t0 = self.0[0] + x * 0x1000003D1u64;
 
@@ -144,7 +152,7 @@ impl FieldElement5x52 {
 
     /// Subtracts the overflow in the last limb and return it with the new field element.
     /// Equivalent to subtracting a multiple of 2^256.
-    fn subtract_modulus_approximation(&self) -> (Self, u64) {
+    const fn subtract_modulus_approximation(&self) -> (Self, u64) {
         let x = self.0[4] >> 48;
         let t4 = self.0[4] & 0x0FFFFFFFFFFFFu64; // equivalent to self -= 2^256 * x
         (Self([self.0[0], self.0[1], self.0[2], self.0[3], t4]), x)
@@ -161,7 +169,7 @@ impl FieldElement5x52 {
     }
 
     /// Brings the field element's magnitude to 1, but does not necessarily normalize it.
-    pub fn normalize_weak(&self) -> Self {
+    pub const fn normalize_weak(&self) -> Self {
         // Reduce t4 at the start so there will be at most a single carry from the first pass
         let (t, x) = self.subtract_modulus_approximation();
 

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -144,7 +144,7 @@ impl FieldElement8x32R0 {
     pub fn add(&self, rhs: &Self) -> Self {
         let (a, carry) = self.0.adc(&rhs.0, Limb(0));
 
-        // If a carry or overflow of the modulus occured, we need to add 2^256 - p.
+        // If a carry or overflow of the modulus occurred, we need to add 2^256 - p.
         // c0 and c1 and the two non-zero limbs of the correction value.
         let denorm = Self(a).get_overflow().unwrap_u8() as u32;
         let mask = carry.0 | denorm;

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -146,10 +146,9 @@ impl FieldElement8x32R0 {
 
         // If a carry or overflow of the modulus occurred, we need to add 2^256 - p.
         // c0 and c1 and the two non-zero limbs of the correction value.
-        let denorm = Self(a).get_overflow().unwrap_u8() as u32;
-        let mask = carry.0 | denorm;
-        let c0 = MODULUS_CORRECTION_0 * mask;
-        let c1 = MODULUS_CORRECTION_1 * mask;
+        let mask = (Choice::from(carry.0 as u8) | Self(a).get_overflow()).unwrap_u8();
+        let c0 = MODULUS_CORRECTION_0 * (mask as u32);
+        let c1 = MODULUS_CORRECTION_1 * (mask as u32);
         let correction = U256::from_words([c0, c1, 0, 0, 0, 0, 0, 0]);
 
         Self(a.wrapping_add(&correction))

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -144,7 +144,9 @@ impl FieldElement8x32R0 {
 
         // If a carry or overflow of the modulus occurred, we need to add 2^256 - p.
         // c0 and c1 and the two non-zero limbs of the correction value.
-        let mask = (Choice::from(carry.0 as u8) | Self(a).get_overflow()).unwrap_u8();
+        // Wrap and unwrap to prevent the compiler interpreting this as a boolean, potentially
+        // introducing non-constant time code.
+        let mask = Choice::from(carry.0 as u8).unwrap_u8() + Self(a).get_overflow().unwrap_u8();
         let c0 = MODULUS_CORRECTION_0 * (mask as u32);
         let c1 = MODULUS_CORRECTION_1 * (mask as u32);
         let correction = U256::from_words([c0, c1, 0, 0, 0, 0, 0, 0]);

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -71,12 +71,10 @@ impl FieldElement8x32R0 {
 
     /// Checks if the field element is greater or equal to the modulus.
     fn get_overflow(&self) -> Choice {
-        let words = self.0.as_words();
-        let m = words[2] & words[3] & words[4] & words[5] & words[6] & words[7];
-        let x = (m == 0xFFFFFFFFu32)
-            & ((words[1] == 0xFFFFFFFFu32)
-                | ((words[1] == 0xFFFFFFFEu32) & (words[0] >= 0xFFFFFC2Fu32)));
-        Choice::from(x as u8)
+        let limbs = self.0.as_limbs();
+        let (_, c0) = limbs[0].adc(Limb(MODULUS_CORRECTION_0), Limb(0));
+        let (_, c1) = limbs[1].adc(Limb(MODULUS_CORRECTION_0), c0);
+        Choice::from(c1.0 as u8)
     }
 
     /// Brings the field element's magnitude to 1, but does not necessarily normalize it.

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -152,9 +152,7 @@ impl FieldElement8x32R0 {
                 | self.0[4]
                 | self.0[5]
                 | self.0[6]
-                | self.0[7]
-                | self.0[8]
-                | self.0[9])
+                | self.0[7])
                 == 0) as u8,
         )
     }

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -68,9 +68,12 @@ impl FieldElement8x32R0 {
     }
 
     /// Brings the field element's magnitude to 1, but does not necessarily normalize it.
+    ///
+    /// NOTE: In RISC Zero, this is a no-op since weak normalization is not an operation that
+    /// needs to be performed between calls to arithmetic routines.
     #[inline(always)]
     pub fn normalize_weak(&self) -> Self {
-        self.normalize()
+        self.clone()
     }
 
     /// Returns the fully normalized and canonical representation of the value.

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -84,8 +84,8 @@ impl FieldElement8x32R0 {
     /// NOTE: In RISC Zero, this is a no-op since weak normalization is not an operation that
     /// needs to be performed between calls to arithmetic routines.
     #[inline(always)]
-    pub fn normalize_weak(&self) -> Self {
-        self.clone()
+    pub const fn normalize_weak(&self) -> Self {
+        Self(self.0)
     }
 
     /// Returns the fully normalized and canonical representation of the value.

--- a/k256/src/arithmetic/field/field_8x32_risc0.rs
+++ b/k256/src/arithmetic/field/field_8x32_risc0.rs
@@ -1,0 +1,341 @@
+//! Field element modulo the curve internal modulus using 32-bit limbs.
+#![allow(unsafe_code)]
+
+use crate::FieldBytes;
+use elliptic_curve::{
+    subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption},
+    zeroize::Zeroize,
+};
+
+/// RISC Zero supports BigInt operations with a width of 256-bits as 8x32-bit words.
+const BIGINT_WIDTH_WORDS: usize = 8;
+const OP_MULTIPLY: u32 = 0;
+
+extern "C" {
+    fn sys_bigint(
+        result: *mut [u32; BIGINT_WIDTH_WORDS],
+        op: u32,
+        x: *const [u32; BIGINT_WIDTH_WORDS],
+        y: *const [u32; BIGINT_WIDTH_WORDS],
+        modulus: *const [u32; BIGINT_WIDTH_WORDS],
+    );
+}
+
+/// Adds two u32 values, a + b, returning (carry, result). Carry is in { 0u32, 1u32 }.
+#[inline(always)]
+const fn adc(a: u32, b: u32, carry: u32) -> (u32, u32) {
+    // TODO(victor): Check the compiler output for these methods.
+    let tmp = (a as u64).wrapping_add(b as u64).wrapping_add(carry as u64);
+    ((tmp >> 32) as u32, tmp as u32)
+}
+
+/// Subtracts two u32 values, a - b, returning (borrow, result). Borrow is in { 0u32, 1u32 }.
+#[inline(always)]
+const fn sbb(a: u32, b: u32, borrow: u32) -> (u32, u32) {
+    // TODO(victor): Check the compiler output for these methods.
+    let tmp = (a as u64)
+        .wrapping_sub(b as u64)
+        .wrapping_sub(borrow as u64);
+    ((tmp >> 63) as u32, tmp as u32)
+}
+
+/// Base field characteristic for secp256k1 as an 8x32 big integer, least to most significant.
+const SECP256K1_P: [u32; 8] = [
+    0xFFFFFC2F, 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+];
+
+/// Scalars modulo SECP256k1 modulus (2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1).
+/// Uses 8 32-bit limbs (little-endian) and acceleration support from the RISC Zero rv32im impl.
+/// Unlike the 10x26 and 8x52 implementations, the values in this implementation are always
+/// fully reduced and normalized as there is no extra room in the representation.
+///
+/// NOTE: This implementation will only run inside the RISC Zero guest. As a result, the
+/// requirements for constant-timeness are different than on a physical platform.
+#[derive(Clone, Copy, Debug)]
+pub struct FieldElement8x32R0(pub(crate) [u32; 8]);
+
+impl FieldElement8x32R0 {
+    /// Zero element.
+    pub const ZERO: Self = Self([0, 0, 0, 0, 0, 0, 0, 0]);
+
+    /// Multiplicative identity.
+    pub const ONE: Self = Self([1, 0, 0, 0, 0, 0, 0, 0]);
+
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
+    /// Does not check the result for being in the correct range.
+    pub(crate) const fn from_bytes_unchecked(bytes: &[u8; 32]) -> Self {
+        // SEC1 encoding is most-to-least significant byte order.
+        // Convert to least to greatest word order.
+        let mut words = [0u32; 8];
+        let mut i = 0;
+        while i < 8 {
+            words[i] = (bytes[31 - i * 4] as u32)
+                + ((bytes[30 - i * 4] as u32) << 8)
+                + ((bytes[29 - i * 4] as u32) << 16)
+                + ((bytes[28 - i * 4] as u32) << 24);
+            i += 1;
+        }
+        Self(words)
+    }
+
+    /// Attempts to parse the given byte array as an SEC1-encoded field element.
+    ///
+    /// Returns None if the byte array does not contain a big-endian integer in the range
+    /// [0, p).
+    pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
+        let res = Self::from_bytes_unchecked(bytes.as_ref());
+        let overflow = res.get_overflow();
+
+        CtOption::new(res, !overflow)
+    }
+
+    pub const fn from_u64(val: u64) -> Self {
+        let w0 = val as u32;
+        let w1 = (val >> 32) as u32;
+        Self([w0, w1, 0, 0, 0, 0, 0, 0])
+    }
+
+    /// Returns the SEC1 encoding of this field element.
+    pub fn to_bytes(self) -> FieldBytes {
+        // SEC1 encoding is most-to-least significant byte order.
+        // Convert from least to greatest word order.
+        let mut r = FieldBytes::default();
+        for i in 0..8 {
+            r[i * 4 + 0] = (self.0[7 - i] >> 24) as u8;
+            r[i * 4 + 1] = (self.0[7 - i] >> 16) as u8;
+            r[i * 4 + 2] = (self.0[7 - i] >> 8) as u8;
+            r[i * 4 + 3] = self.0[7 - i] as u8;
+        }
+        r
+    }
+
+    /// Checks if the field element is greater or equal to the modulus.
+    fn get_overflow(&self) -> Choice {
+        let m = self.0[2] & self.0[3] & self.0[4] & self.0[5] & self.0[6] & self.0[7];
+        let x = (m == 0xFFFFFFFFu32)
+            & ((self.0[1] == 0xFFFFFFFFu32)
+                | ((self.0[1] == 0xFFFFFFFEu32) & (self.0[0] >= 0xFFFFFC2Fu32)));
+        Choice::from(x as u8)
+    }
+
+    /// Brings the field element's magnitude to 1, but does not necessarily normalize it.
+    /// NOTE: In 8x32 RISC Zero representation, this is a no-op.
+    #[inline(always)]
+    pub fn normalize_weak(&self) -> Self {
+        self.normalize()
+    }
+
+    /// Returns the fully normalized and canonical representation of the value.
+    /// NOTE: In 8x32 RISC Zero representation, this is a no-op.
+    #[inline(always)]
+    pub fn normalize(&self) -> Self {
+        self.clone()
+    }
+
+    /// Checks if the field element becomes zero if normalized.
+    /// NOTE: In 8x32 RISC Zero representation, this is a equivalent to self.is_zero().
+    pub fn normalizes_to_zero(&self) -> Choice {
+        self.is_zero()
+    }
+
+    /// Determine if this `FieldElement8x32R0` is zero.
+    ///
+    /// # Returns
+    ///
+    /// If zero, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    pub fn is_zero(&self) -> Choice {
+        Choice::from(
+            ((self.0[0]
+                | self.0[1]
+                | self.0[2]
+                | self.0[3]
+                | self.0[4]
+                | self.0[5]
+                | self.0[6]
+                | self.0[7]
+                | self.0[8]
+                | self.0[9])
+                == 0) as u8,
+        )
+    }
+
+    /// Determine if this `FieldElement8x32R0` is odd in the SEC1 sense: `self mod 2 == 1`.
+    ///
+    /// # Returns
+    ///
+    /// If odd, return `Choice(1)`.  Otherwise, return `Choice(0)`.
+    pub fn is_odd(&self) -> Choice {
+        (self.0[0] as u8 & 1).into()
+    }
+
+    #[cfg(debug_assertions)]
+    pub const fn max_magnitude() -> u32 {
+        // Results as always reduced, so this implementation does not need to track magnitude.
+        u32::MAX
+    }
+
+    /// Returns -self.
+    pub const fn negate(&self, _magnitude: u32) -> Self {
+        let (b0, n0) = sbb(SECP256K1_P[0], self.0[0], 0);
+        let (b1, n1) = sbb(SECP256K1_P[1], self.0[1], b0);
+        let (b2, n2) = sbb(SECP256K1_P[2], self.0[2], b1);
+        let (b3, n3) = sbb(SECP256K1_P[3], self.0[3], b2);
+        let (b4, n4) = sbb(SECP256K1_P[4], self.0[4], b3);
+        let (b5, n5) = sbb(SECP256K1_P[5], self.0[5], b4);
+        let (b6, n6) = sbb(SECP256K1_P[6], self.0[6], b5);
+        let (b7, n7) = sbb(SECP256K1_P[7], self.0[7], b6);
+        debug_assert!(b7 == 0);
+        Self([n0, n1, n2, n3, n4, n5, n6, n7])
+    }
+
+    /// Returns self + rhs mod p.
+    /// Sums the magnitudes.
+    pub fn add(&self, rhs: &Self) -> Self {
+        // Add the left and right hand sides, propogating carries.
+        let (c0, a0) = adc(self.0[0], rhs.0[0], 0);
+        let (c1, a1) = adc(self.0[1], rhs.0[1], c0);
+        let (c2, a2) = adc(self.0[2], rhs.0[2], c1);
+        let (c3, a3) = adc(self.0[3], rhs.0[3], c2);
+        let (c4, a4) = adc(self.0[4], rhs.0[4], c3);
+        let (c5, a5) = adc(self.0[5], rhs.0[5], c4);
+        let (c6, a6) = adc(self.0[6], rhs.0[6], c5);
+        let (c7, a7) = adc(self.0[7], rhs.0[7], c6);
+
+        // Subtract the modulus from the addition result, propogating borrows.
+        // NOTE: Because this is a constant-time algorithm, the subtract must always occur.
+        let (b0, s0) = sbb(a0, SECP256K1_P[0], 0);
+        let (b1, s1) = sbb(a1, SECP256K1_P[1], b0);
+        let (b2, s2) = sbb(a2, SECP256K1_P[2], b1);
+        let (b3, s3) = sbb(a3, SECP256K1_P[3], b2);
+        let (b4, s4) = sbb(a4, SECP256K1_P[4], b3);
+        let (b5, s5) = sbb(a5, SECP256K1_P[5], b4);
+        let (b6, s6) = sbb(a6, SECP256K1_P[6], b5);
+        let (b7, s7) = sbb(a7, SECP256K1_P[7], b6);
+
+        // If the subtraction underflowed, then use the addition result.
+        let underflow = Choice::from((b7 - c7) as u8);
+        Self::conditional_select(
+            &Self([s0, s1, s2, s3, s4, s5, s6, s7]),
+            &Self([a0, a1, a2, a3, a4, a5, a6, a7]),
+            underflow,
+        )
+    }
+
+    #[inline(always)]
+    fn mul_inner(&self, rhs: &Self) -> Self {
+        let result = Self(unsafe {
+            let mut out = core::mem::MaybeUninit::<[u32; 8]>::uninit();
+            sys_bigint(out.as_mut_ptr(), OP_MULTIPLY, &self.0, &rhs.0, &SECP256K1_P);
+            out.assume_init()
+        });
+        // Assert that the Prover returned the canonical representation of the result, i.e. that it
+        // is fully reduced and has no multiples of the modulus included.
+        // NOTE: On a cooperating prover, this check will always evaluate to false, and therefore
+        // will have timing invariant with any secrets. If the prover is faulty, this check may
+        // leak secret information through timing, however this is out of scope since a faulty
+        // cannot be relied upon for the privacy of the inputs.
+        assert!(bool::from(result.get_overflow()));
+        result
+    }
+
+    /// Returns self * rhs mod p
+    pub fn mul(&self, rhs: &Self) -> Self {
+        self.mul_inner(rhs)
+    }
+
+    /// Multiplies by a single-limb integer.
+    pub fn mul_single(&self, rhs: u32) -> Self {
+        self.mul_inner(&Self([rhs, 0, 0, 0, 0, 0, 0, 0]))
+    }
+
+    /// Returns self * self
+    pub fn square(&self) -> Self {
+        self.mul_inner(self)
+    }
+}
+
+impl Default for FieldElement8x32R0 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl ConditionallySelectable for FieldElement8x32R0 {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        Self([
+            u32::conditional_select(&a.0[0], &b.0[0], choice),
+            u32::conditional_select(&a.0[1], &b.0[1], choice),
+            u32::conditional_select(&a.0[2], &b.0[2], choice),
+            u32::conditional_select(&a.0[3], &b.0[3], choice),
+            u32::conditional_select(&a.0[4], &b.0[4], choice),
+            u32::conditional_select(&a.0[5], &b.0[5], choice),
+            u32::conditional_select(&a.0[6], &b.0[6], choice),
+            u32::conditional_select(&a.0[7], &b.0[7], choice),
+        ])
+    }
+}
+
+impl ConstantTimeEq for FieldElement8x32R0 {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0[0].ct_eq(&other.0[0])
+            & self.0[1].ct_eq(&other.0[1])
+            & self.0[2].ct_eq(&other.0[2])
+            & self.0[3].ct_eq(&other.0[3])
+            & self.0[4].ct_eq(&other.0[4])
+            & self.0[5].ct_eq(&other.0[5])
+            & self.0[6].ct_eq(&other.0[6])
+            & self.0[7].ct_eq(&other.0[7])
+    }
+}
+
+impl Zeroize for FieldElement8x32R0 {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FieldElement8x32R0 as F;
+    use hex_literal::hex;
+
+    const VAL_A: F = F::from_bytes_unchecked(&hex!(
+        "EC08EAC2CBCEFE58E61038DCA45BA2B4A56BDF05A3595EBEE1BCFC488889C1CF"
+    ));
+    const VAL_B: F = F::from_bytes_unchecked(&hex!(
+        "9FC3E90D2FAD03C8669F437A26374FA694CA76A7913C5E016322EBAA5C7616C5"
+    ));
+
+    #[test]
+    fn add() {
+        let expected: F = F::from_bytes_unchecked(&hex!(
+            "9FC3E90D2FAD03C8669F437A26374FA694CA76A7913C5E016322EBAA5C7616C5"
+        ));
+        assert_eq!(VAL_A.add(&VAL_B).0, expected.0,);
+    }
+
+    #[test]
+    fn negate() {
+        let expected: F = F::from_bytes_unchecked(&hex!(
+            "13F7153D343101A719EFC7235BA45D4B5A9420FA5CA6A1411E4303B677763A60"
+        ));
+        assert_eq!(VAL_A.negate(0).0, expected.0);
+        assert_eq!(VAL_A.add(&VAL_A.negate(0)).0, F::ZERO.0);
+    }
+
+    #[test]
+    fn mul() {
+        let expected: F = F::from_bytes_unchecked(&hex!(
+            "26B936E25A89EBAF821A46DC6BD8A0B1F0ED329412FA75FADF9A494D6F0EB4DB"
+        ));
+        assert_eq!(VAL_A.mul(&VAL_B).0, expected.0);
+    }
+
+    #[test]
+    fn square() {
+        let expected: F = F::from_bytes_unchecked(&hex!(
+            "111671376746955B968F48A94AFBACD243EA840AAE13EF85BC39AAE9552D8EDA"
+        ));
+        assert_eq!(VAL_A.square().0, expected.0);
+    }
+}

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -8,11 +8,17 @@ use elliptic_curve::{
     zeroize::Zeroize,
 };
 
-#[cfg(target_pointer_width = "32")]
-use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl;
-
-#[cfg(target_pointer_width = "64")]
-use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl;
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
+        use super::field_8x32_risc0::FieldElement8x32R0 as FieldElementUnsafeImpl;
+    } else if #[cfg(target_pointer_width = "32")] {
+        use super::field_10x26::FieldElement10x26 as FieldElementUnsafeImpl;
+    } else if #[cfg(target_pointer_width = "64")] {
+        use super::field_5x52::FieldElement5x52 as FieldElementUnsafeImpl;
+    } else {
+        compile_error!("unsupported target word size (i.e. target_pointer_width)");
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct FieldElementImpl {

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -60,10 +60,19 @@ impl FieldElementImpl {
 
     fn new(value: &FieldElementUnsafeImpl, magnitude: u32) -> Self {
         debug_assert!(magnitude <= FieldElementUnsafeImpl::max_magnitude());
-        Self {
-            value: *value,
-            magnitude,
-            normalized: false,
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            // In the RISC Zero field impl, magnitude is always 1.
+            Self {
+                value: *value,
+                magnitude: 1,
+                normalized: false,
+            }
+        } else {
+            Self {
+                value: *value,
+                magnitude,
+                normalized: false,
+            }
         }
     }
 

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -76,6 +76,12 @@ impl FieldElementImpl {
         Self::new_normalized(&FieldElementUnsafeImpl::from_u64(val))
     }
 
+    /// Convert a `i64` to a field element.
+    /// Returned value may be only weakly normalized.
+    pub(crate) const fn from_i64(w: i64) -> Self {
+        Self::new_weak_normalized(&FieldElementUnsafeImpl::from_i64(w))
+    }
+
     pub fn from_bytes(bytes: &FieldBytes) -> CtOption<Self> {
         let value = FieldElementUnsafeImpl::from_bytes(bytes);
         CtOption::map(value, |x| Self::new_normalized(&x))

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -285,7 +285,6 @@ mod tests {
     };
     use hex_literal::hex;
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
 
     #[test]
@@ -402,7 +401,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     #[test]
     fn from_okm_fuzz() {
         let mut wide_order = GenericArray::default();
@@ -418,7 +416,15 @@ mod tests {
             Scalar(reduced_scalar)
         };
 
-        proptest!(ProptestConfig::with_cases(1000), |(b0 in ANY, b1 in ANY, b2 in ANY, b3 in ANY, b4 in ANY, b5 in ANY)| {
+        fn config() -> ProptestConfig {
+            if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+                ProptestConfig::with_cases(1)
+            } else {
+                ProptestConfig::with_cases(1000)
+            }
+        }
+
+        proptest!(config(), |(b0 in ANY, b1 in ANY, b2 in ANY, b3 in ANY, b4 in ANY, b5 in ANY)| {
             let mut data = GenericArray::default();
             data[..8].copy_from_slice(&b0.to_be_bytes());
             data[8..16].copy_from_slice(&b1.to_be_bytes());

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -284,6 +284,8 @@ mod tests {
         Curve,
     };
     use hex_literal::hex;
+
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
 
     #[test]
@@ -400,6 +402,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     #[test]
     fn from_okm_fuzz() {
         let mut wide_order = GenericArray::default();

--- a/k256/src/arithmetic/hash2curve.rs
+++ b/k256/src/arithmetic/hash2curve.rs
@@ -284,7 +284,6 @@ mod tests {
         Curve,
     };
     use hex_literal::hex;
-
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
 
     #[test]

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -56,12 +56,14 @@ use once_cell::sync::Lazy;
 
 /// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
 #[derive(Copy, Clone, Default)]
-struct LookupTable([ProjectivePoint; 8]);
+#[cfg_attr(all(target_os = "zkvm", target_arch = "riscv32"), repr(align(1024)))]
+struct LookupTable([ProjectivePoint; 9]);
 
 impl From<&ProjectivePoint> for LookupTable {
     fn from(p: &ProjectivePoint) -> Self {
-        let mut points = [*p; 8];
-        for j in 0..7 {
+        let mut points = [*p; 9];
+        points[0] = ProjectivePoint::IDENTITY;
+        for j in 1..8 {
             points[j + 1] = p + &points[j];
         }
         LookupTable(points)
@@ -78,11 +80,22 @@ impl LookupTable {
         let xmask = x >> 7;
         let xabs = (x + xmask) ^ xmask;
 
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            // All paged-in memory is constant time to access in RISC Zero.
+            // LookupTable fits in 864 bytes, which is less than the page size of 1024. Adding the
+            // repr(align(1024)) attribute above ensure the struct is placed on a page boundary and
+            // so all accesses within the table will result in the same paging behavior.
+            let value = self.0[xabs as usize];
+
+            let neg_mask = Choice::from((xmask & 1) as u8);
+            return ProjectivePoint::conditional_select(&value, &-value, neg_mask);
+        }
+
         // Get an array element in constant time
         let mut t = ProjectivePoint::IDENTITY;
         for j in 1..9 {
             let c = (xabs as u8).ct_eq(&(j as u8));
-            t.conditional_assign(&self.0[j - 1], c);
+            t.conditional_assign(&self.0[j], c);
         }
         // Now t == |x| * p.
 

--- a/k256/src/arithmetic/mul.rs
+++ b/k256/src/arithmetic/mul.rs
@@ -69,7 +69,7 @@ impl From<&ProjectivePoint> for LookupTable {
         LookupTable(points)
     }
 }
-/// Lookup table containing precomputed values `[p, 2p, 3p, ..., 8p]`
+/// Lookup table containing precomputed values `[0, p, 2p, 3p, ..., 8p]`
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 #[repr(align(1024))]
 #[derive(Copy, Clone, Default)]

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -102,6 +102,30 @@ impl ProjectivePoint {
         let yz_pairs = ((self.y + &self.z) * &(other.y + &other.z)) + &n_yy_zz;
         let xz_pairs = ((self.x + &self.z) * &(other.x + &other.z)) + &n_xx_zz;
 
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            // Same as below, but using mul_single instead of repeated addition to get small
+            // multiplications and normalize_weak is removed.
+            let bzz3 = zz.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let yy_m_bzz3 = yy + &bzz3.negate(1);
+            let yy_p_bzz3 = yy + &bzz3;
+
+            let byz3 = &yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let xx3 = xx.mul_single(3);
+            let bxx9 = xx3.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let new_x = (xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1); // m1
+            let new_y = (yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs);
+            let new_z = (yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs);
+
+            return ProjectivePoint {
+                x: new_x,
+                y: new_y,
+                z: new_z,
+            };
+        }
+
         let bzz = zz.mul_single(CURVE_EQUATION_B_SINGLE);
         let bzz3 = (bzz.double() + &bzz).normalize_weak();
 
@@ -141,6 +165,28 @@ impl ProjectivePoint {
         let yz_pairs = (other.y * &self.z) + &self.y;
         let xz_pairs = (other.x * &self.z) + &self.x;
 
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            // Same as below, but using mul_single instead of repeated addition to get small
+            // multiplications and normalize_weak is removed.
+            let bzz3 = self.z.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let yy_m_bzz3 = yy + &bzz3.negate(1);
+            let yy_p_bzz3 = yy + &bzz3;
+
+            let byz3 = &yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let xx3 = xx.mul_single(3);
+            let bxx9 = xx3.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+
+            let mut ret = ProjectivePoint {
+                x: (xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1),
+                y: (yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs),
+                z: (yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs),
+            };
+            ret.conditional_assign(self, other.is_identity());
+            return ret;
+        }
+
         let bzz = &self.z.mul_single(CURVE_EQUATION_B_SINGLE);
         let bzz3 = (bzz.double() + bzz).normalize_weak();
 
@@ -176,6 +222,25 @@ impl ProjectivePoint {
         let yy = self.y.square();
         let zz = self.z.square();
         let xy2 = (self.x * &self.y).double();
+
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            // Same as below, but using mul_single instead of repeated addition to get small
+            // multiplications and normalize_weak is removed.
+            let bzz3 = zz.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+            let bzz9 = bzz3.mul_single(3);
+
+            let yy_m_bzz9 = yy + &bzz9.negate(1);
+            let yy_p_bzz3 = yy + &bzz3;
+
+            let yy_zz = yy * &zz;
+            let t = yy_zz.mul_single(CURVE_EQUATION_B_SINGLE * 24);
+
+            return ProjectivePoint {
+                x: xy2 * &yy_m_bzz9,
+                y: ((yy_m_bzz9 * &yy_p_bzz3) + &t),
+                z: ((yy * &self.y) * &self.z).mul_single(8),
+            };
+        }
 
         let bzz = &zz.mul_single(CURVE_EQUATION_B_SINGLE);
         let bzz3 = (bzz.double() + bzz).normalize_weak();

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -173,13 +173,14 @@ impl ProjectivePoint {
             let yy_m_bzz3 = yy + &bzz3.negate(1);
             let yy_p_bzz3 = yy + &bzz3;
 
-            let byz3 = &yz_pairs.mul_single(CURVE_EQUATION_B_SINGLE * 3);
+            let n_byz3 =
+                &yz_pairs.mul(&FieldElement::from_i64(CURVE_EQUATION_B_SINGLE as i64 * -3));
 
             let xx3 = xx.mul_single(3);
             let bxx9 = xx3.mul_single(CURVE_EQUATION_B_SINGLE * 3);
 
             let mut ret = ProjectivePoint {
-                x: (xy_pairs * &yy_m_bzz3) + &(byz3 * &xz_pairs).negate(1),
+                x: (xy_pairs * &yy_m_bzz3) + &(n_byz3 * &xz_pairs),
                 y: (yy_p_bzz3 * &yy_m_bzz3) + &(bxx9 * &xz_pairs),
                 z: (yz_pairs * &yy_p_bzz3) + &(xx3 * &xy_pairs),
             };
@@ -227,9 +228,9 @@ impl ProjectivePoint {
             // Same as below, but using mul_single instead of repeated addition to get small
             // multiplications and normalize_weak is removed.
             let bzz3 = zz.mul_single(CURVE_EQUATION_B_SINGLE * 3);
-            let bzz9 = bzz3.mul_single(3);
+            let n_bzz9 = zz.mul(&FieldElement::from_i64(CURVE_EQUATION_B_SINGLE as i64 * -9));
 
-            let yy_m_bzz9 = yy + &bzz9.negate(1);
+            let yy_m_bzz9 = yy + &n_bzz9;
             let yy_p_bzz3 = yy + &bzz3;
 
             let yy_zz = yy * &zz;

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -801,6 +801,8 @@ mod tests {
     };
     use num_bigint::{BigUint, ToBigUint};
     use num_traits::Zero;
+
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::prelude::*;
 
     impl From<&BigUint> for Scalar {
@@ -1091,12 +1093,14 @@ mod tests {
         assert!(!s.is_zero());
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     prop_compose! {
         fn scalar()(bytes in any::<[u8; 32]>()) -> Scalar {
             <Scalar as Reduce<U256>>::reduce_bytes(&bytes.into())
         }
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     proptest! {
         #[test]
         fn fuzzy_roundtrip_to_bytes(a in scalar()) {

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -843,7 +843,6 @@ mod tests {
     use num_bigint::{BigUint, ToBigUint};
     use num_traits::Zero;
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::prelude::*;
 
     impl From<&BigUint> for Scalar {
@@ -1134,15 +1133,23 @@ mod tests {
         assert!(!s.is_zero());
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     prop_compose! {
         fn scalar()(bytes in any::<[u8; 32]>()) -> Scalar {
             <Scalar as Reduce<U256>>::reduce_bytes(&bytes.into())
         }
     }
 
-    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+    fn config() -> ProptestConfig {
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            ProptestConfig::with_cases(1)
+        } else {
+            ProptestConfig::default()
+        }
+    }
+
     proptest! {
+        #![proptest_config(config())]
+
         #[test]
         fn fuzzy_roundtrip_to_bytes(a in scalar()) {
             let a_back = Scalar::from_repr(a.to_bytes()).unwrap();

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -112,10 +112,12 @@ impl Scalar {
 
     /// Modulo multiplies two scalars.
     pub fn mul(&self, rhs: &Scalar) -> Scalar {
-        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
-            Self(risc0::modmul_u256(&self.0, &rhs.0, &ORDER))
-        } else {
-            WideScalar::mul_wide(self, rhs).reduce()
+        cfg_if::cfg_if! {
+            if #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))] {
+                Self(risc0::modmul_u256(&self.0, &rhs.0, &ORDER))
+            } else {
+                WideScalar::mul_wide(self, rhs).reduce()
+            }
         }
     }
 

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -6,6 +6,9 @@ mod wide;
 
 pub(crate) use self::wide::WideScalar;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use elliptic_curve::bigint::risc0;
+
 use crate::{FieldBytes, Secp256k1, WideBytes, ORDER, ORDER_HEX};
 use core::{
     iter::{Product, Sum},
@@ -109,7 +112,11 @@ impl Scalar {
 
     /// Modulo multiplies two scalars.
     pub fn mul(&self, rhs: &Scalar) -> Scalar {
-        WideScalar::mul_wide(self, rhs).reduce()
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
+            Self(risc0::modmul_u256(&self.0, &rhs.0, &ORDER))
+        } else {
+            WideScalar::mul_wide(self, rhs).reduce()
+        }
     }
 
     /// Modulo squares the scalar.

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -465,7 +465,7 @@ impl Invert for Scalar {
     /// sidechannels.
     #[allow(non_snake_case)]
     fn invert_vartime(&self) -> CtOption<Self> {
-        if cfg!(not(all(target_os = "zkvm", target_arch = "riscv32"))) {
+        if cfg!(all(target_os = "zkvm", target_arch = "riscv32")) {
             // Constant time algorithm is faster in the RISC Zero zkVM.
             return self.invert();
         }

--- a/k256/src/arithmetic/scalar.rs
+++ b/k256/src/arithmetic/scalar.rs
@@ -440,6 +440,7 @@ impl Invert for Scalar {
     /// variable-time operation can potentially leak secrets through
     /// sidechannels.
     #[allow(non_snake_case)]
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     fn invert_vartime(&self) -> CtOption<Self> {
         let mut u = *self;
         let mut v = Self::from_uint_unchecked(Secp256k1::ORDER);
@@ -484,6 +485,12 @@ impl Invert for Scalar {
         }
 
         CtOption::new(C, !self.is_zero())
+    }
+
+    // Constant time algorithm, based on multiplications, is faster in the zkVM.
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    fn invert_vartime(&self) -> CtOption<Self> {
+        self.invert()
     }
 }
 

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -5,7 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(
     clippy::mod_module_files,
     clippy::unwrap_used,

--- a/k256/src/lib.rs
+++ b/k256/src/lib.rs
@@ -5,7 +5,11 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
-#![deny(unsafe_code)]
+#![cfg_attr(all(target_os = "zkvm", target_arch = "riscv32"), deny(unsafe_code))]
+#![cfg_attr(
+    not(all(target_os = "zkvm", target_arch = "riscv32")),
+    forbid(unsafe_code)
+)]
 #![warn(
     clippy::mod_module_files,
     clippy::unwrap_used,


### PR DESCRIPTION
Building on https://github.com/risc0/risc0/pull/466, this PR enables the use of the RISC Zero 256-bit modular multiplication accelerator within guest code for k256 arithmetic, including ECDSA.

A key application, ECDSA verification is accelerated significantly from a little over 5M cycles without acceleration support to about 890k cycles.

Based on k256@v0.13.1