### PR TITLE
Use risc0-bigint2 v1.4.0

### DIFF
--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -1,0 +1,28 @@
+name: Find or Create Linear Issue for PR
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: ["opened", "edited", "reopened", "synchronize"]
+
+permissions:
+  pull-requests: write
+  repository-projects: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-linear-issue-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find or create a Linear Issue
+        uses: risc0/action-find-or-create-linear-issue@risc0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          linear-api-key: ${{ secrets.LINEAR_API_KEY }}
+          linear-team-key: "ZKVM"
+          linear-created-issue-state-id: "791f9982-af09-4b03-99b3-717754da12d0" # in-progress

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -28,7 +28,9 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
 bytemuck = "1"
-risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+# TODO: Use a real version once released
+# risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
+risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "4c65c85a1ec6ce7df165ef9c57e1e13e323f7e01", features = ["unstable"] }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -28,9 +28,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
 bytemuck = "1"
-# TODO: Use a real version once released
-# risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
-risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "4c65c85a1ec6ce7df165ef9c57e1e13e323f7e01", features = ["unstable"] }
+risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -23,9 +23,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["arit
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-# TODO: Use a real version onece released
-# risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
-risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "4c65c85a1ec6ce7df165ef9c57e1e13e323f7e01", features = ["unstable"] }
+risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
 bytemuck = "1"
 
 [features]

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -23,7 +23,9 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["arit
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+# TODO: Use a real version onece released
+# risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
+risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "4c65c85a1ec6ce7df165ef9c57e1e13e323f7e01", features = ["unstable"] }
 bytemuck = "1"
 
 [features]

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -65,12 +65,12 @@ where
             }
             let z = felt_to_u32_words_le::<C>(&self.z);
             let mut z_inv = [0u32; 8];
-            risc0_bigint2::field::modinv_256_unchecked(&z, &C::PRIME_LE_WORDS, &mut z_inv);
+            risc0_bigint2::field::unchecked::modinv_256(&z, &C::PRIME_LE_WORDS, &mut z_inv);
 
             let mut buffer = [0u32; 8];
             let x_buffer = felt_to_u32_words_le::<C>(&self.x);
             let y_buffer = felt_to_u32_words_le::<C>(&self.y);
-            risc0_bigint2::field::modmul_256_unchecked(
+            risc0_bigint2::field::unchecked::modmul_256(
                 &x_buffer,
                 &z_inv,
                 &C::PRIME_LE_WORDS,
@@ -79,7 +79,7 @@ where
 
             let x = C::from_u32_words_le(buffer);
 
-            risc0_bigint2::field::modmul_256_unchecked(
+            risc0_bigint2::field::unchecked::modmul_256(
                 &y_buffer,
                 &z_inv,
                 &C::PRIME_LE_WORDS,

--- a/primeorder/src/risc0.rs
+++ b/primeorder/src/risc0.rs
@@ -76,7 +76,7 @@ where
 {
     #[inline]
     pub fn mul_unchecked(&self, rhs: &Self, result: &mut Self) {
-        risc0_bigint2::field::modmul_256_unchecked(
+        risc0_bigint2::field::unchecked::modmul_256(
             &self.data,
             &rhs.data,
             &C::PRIME_LE_WORDS,
@@ -96,7 +96,7 @@ where
 
     #[inline]
     pub fn add_unchecked(&self, rhs: &Self, result: &mut Self) {
-        risc0_bigint2::field::modadd_256_unchecked(
+        risc0_bigint2::field::unchecked::modadd_256(
             &self.data,
             &rhs.data,
             &C::PRIME_LE_WORDS,


### PR DESCRIPTION
Updates this patch to depend on version `1.4.0` of `risc0-bigint2`. See also #12 about the renamings from that update.