### PR TITLE
Dual p256 & p384 support

### DIFF
--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -1,0 +1,28 @@
+name: Find or Create Linear Issue for PR
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: ["opened", "edited", "reopened", "synchronize"]
+
+permissions:
+  pull-requests: write
+  repository-projects: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-linear-issue-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find or create a Linear Issue
+        uses: risc0/action-find-or-create-linear-issue@risc0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          linear-api-key: ${{ secrets.LINEAR_API_KEY }}
+          linear-team-key: "ZKVM"
+          linear-created-issue-state-id: "791f9982-af09-4b03-99b3-717754da12d0" # in-progress

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,7 @@ name = "p384"
 version = "0.13.0"
 dependencies = [
  "blobby",
+ "bytemuck",
  "criterion",
  "ecdsa",
  "elliptic-curve",
@@ -1754,6 +1755,7 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
+ "risc0-bigint2",
  "serdect",
  "sha2",
 ]
@@ -2212,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.2.1"
+version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7549b31ad8d81afea787c807803a592bc73151926bbb951a6823e23d998c34f0"
+checksum = "af3997ed5c8a35afd2fa39055f1b841e19571379e55ee634a06c41d7b924052d"
 dependencies = [
  "include_bytes_aligned",
  "stability",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,225 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.1"
+name = "anyhow"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "critical-section",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2",
+ "derivative",
+ "digest",
+ "sha2",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
+dependencies = [
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -35,16 +242,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -68,6 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,10 +323,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -92,6 +350,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bonsai-sdk"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7ecaa1f078d094627e8413f6d5623c3605b40327194f8e6857b6af7da24587"
+dependencies = [
+ "duplicate",
+ "maybe-async",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2593a3b8b938bd68373196c9832f516be11fa487ef4ae745eb282e6a56a7244"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -119,10 +413,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytemuck"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cast"
@@ -132,15 +487,24 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -175,9 +539,9 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.2",
  "textwrap",
 ]
 
@@ -195,6 +559,33 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -243,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -324,15 +715,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
+name = "derivative"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "docker-generate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck",
+ "proc-macro-error",
 ]
 
 [[package]]
@@ -354,6 +810,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
 name = "elliptic-curve"
@@ -379,6 +841,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -428,10 +896,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -446,14 +1012,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "group"
@@ -479,6 +1053,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +1090,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
@@ -521,13 +1122,264 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -550,6 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,10 +1424,11 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -604,6 +1463,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,9 +1493,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -622,10 +1504,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
@@ -637,12 +1535,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -687,13 +1652,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.1"
+name = "objc"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
- "atomic-polyfill",
+ "malloc_buf",
+]
+
+[[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
  "critical-section",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -701,6 +1684,12 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -739,6 +1728,7 @@ name = "p256"
 version = "0.13.2"
 dependencies = [
  "blobby",
+ "bytemuck",
  "criterion",
  "ecdsa",
  "elliptic-curve",
@@ -746,6 +1736,8 @@ dependencies = [
  "primeorder",
  "proptest",
  "rand_core",
+ "risc0-bigint2",
+ "risc0-zkvm",
  "serdect",
  "sha2",
 ]
@@ -775,6 +1767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +1780,24 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -822,6 +1838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,15 +1853,50 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 name = "primeorder"
 version = "0.13.1"
 dependencies = [
+ "bytemuck",
  "elliptic-curve",
+ "risc0-bigint2",
  "serdect",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.51"
+name = "proc-macro-crate"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -851,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -859,10 +1916,33 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.6.28",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -878,10 +1958,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quote"
-version = "1.0.23"
+name = "quinn"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.6",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.6",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -959,16 +2091,41 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
- "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -976,6 +2133,57 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "windows-registry",
+]
 
 [[package]]
 name = "rfc6979"
@@ -988,17 +2196,299 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7549b31ad8d81afea787c807803a592bc73151926bbb951a6823e23d998c34f0"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
+]
+
+[[package]]
+name = "risc0-binfmt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d38498a55589122b195aa5024d2c0b02231efdb01c090881b9d535660f97c9"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "elf",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-build"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b178bec61b5a589feeddcc8f9987119dccfd32f17d98dfedf14921591b35bf4"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "dirs",
+ "docker-generate",
+ "hex",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "risc0-circuit-keccak"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723af53138c76e5c167f52c0396071ebd735a79561732de974dabb545ba2d1be"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "paste",
+ "risc0-binfmt",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-recursion"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c7665d06d6dd42bff80dd7690fddecc49b664621336ad0542505e139a470ad"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "hex",
+ "metal",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c44a97bf5f90a90a51fcc3667b12592a407431f7bab34dc5e77f097675699d"
+dependencies = [
+ "anyhow",
+ "metal",
+ "risc0-binfmt",
+ "risc0-core",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-core"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f45bab0bb477240e7d45a25e618603ef4196421728a115b6d4b7a6036535a5"
+dependencies = [
+ "bytemuck",
+ "rand_core",
+]
+
+[[package]]
+name = "risc0-groth16"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a73e92874649e10cbdd6b3069c4f0f6a7daab1251d18ba8b190ef9f99b39975c"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec",
+ "ark-groth16",
+ "ark-serialize",
+ "bytemuck",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "serde",
+ "stability",
+]
+
+[[package]]
+name = "risc0-zkp"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f1990995a8933cdd1812dc9d8d0e5f04032a045cc47ef00557996b566e2194"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "borsh",
+ "bytemuck",
+ "cfg-if",
+ "digest",
+ "hex",
+ "hex-literal",
+ "metal",
+ "paste",
+ "rand_core",
+ "risc0-core",
+ "risc0-zkvm-platform",
+ "serde",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7dd5caa549aa61f00a69f2b625b0d4e42e40595f3d0b29773c80856baa244fd"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bonsai-sdk",
+ "borsh",
+ "bytemuck",
+ "bytes",
+ "getrandom",
+ "hex",
+ "lazy-regex",
+ "prost",
+ "risc0-binfmt",
+ "risc0-build",
+ "risc0-circuit-keccak",
+ "risc0-circuit-recursion",
+ "risc0-circuit-rv32im",
+ "risc0-core",
+ "risc0-groth16",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rrs-lib",
+ "semver",
+ "serde",
+ "sha2",
+ "stability",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm-platform"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b825852cf55c5f54f1f21d178055e6959fa5f4e839eab2ad56cfd377d2e7f8"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "getrandom",
+ "libm",
+ "stability",
+]
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1050,23 +2540,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.152"
+name = "semver"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.216"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1075,6 +2574,18 @@ version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1112,6 +2623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +2636,15 @@ checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1146,6 +2672,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,10 +2704,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
+name = "stability"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1170,6 +2734,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1198,6 +2793,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+dependencies = [
+ "thiserror-impl 2.0.6",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +2851,130 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.7.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1224,6 +2993,41 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1252,6 +3056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,34 +3072,47 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.84"
+name = "wasm-bindgen-futures"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1294,31 +3120,63 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1353,18 +3211,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -1373,7 +3261,34 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1382,13 +3297,44 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1398,10 +3344,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1410,10 +3380,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1422,16 +3422,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -1443,7 +3500,108 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.5.7"
+name = "yoke"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
 bytemuck = "1"
-risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
 
 [dev-dependencies]
 blobby = "0.3"

--- a/p256/Cargo.toml
+++ b/p256/Cargo.toml
@@ -26,14 +26,23 @@ primeorder = { version = "0.13", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+bytemuck = "1"
+risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+
 [dev-dependencies]
 blobby = "0.3"
-criterion = "0.4"
 ecdsa-core = { version = "0.16", package = "ecdsa", default-features = false, features = ["dev"] }
 hex-literal = "0.4"
 primeorder = { version = "0.13", features = ["dev"], path = "../primeorder" }
-proptest = "1"
 rand_core = { version = "0.6", features = ["getrandom"] }
+
+[target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
+proptest = "1"
+criterion = "0.4"
+
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
+risc0-zkvm = { version = "1.2.1", features = ["getrandom"] }
 
 [features]
 default = ["arithmetic", "ecdsa", "pem", "std"]

--- a/p256/benches/field.rs
+++ b/p256/benches/field.rs
@@ -1,4 +1,5 @@
 //! secp256r1 field element benchmarks
+#![cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,

--- a/p256/benches/scalar.rs
+++ b/p256/benches/scalar.rs
@@ -1,5 +1,7 @@
 //! secp256r1 scalar arithmetic benchmarks
 
+#![cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, Criterion,
 };

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -31,6 +31,9 @@ impl PrimeCurveArithmetic for NistP256 {
     type CurveGroup = ProjectivePoint;
 }
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use primeorder::__risc0::FieldElement256;
+
 /// Adapted from [NIST SP 800-186] § G.1.2: Curve P-256.
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
@@ -56,4 +59,23 @@ impl PrimeCurveParams for NistP256 {
         FieldElement::from_hex("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"),
         FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
     );
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    const PRIME_LE_WORDS: [u32; 8] = crate::__risc0::SECP256R1_PRIME;
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    const ORDER_LE_WORDS: [u32; 8] = crate::__risc0::SECP256R1_ORDER;
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    const EQUATION_A_LE: FieldElement256<NistP256> =
+        FieldElement256::new_unchecked(crate::__risc0::SECP256R1_EQUATION_A_LE);
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    const EQUATION_B_LE: FieldElement256<NistP256> =
+        FieldElement256::new_unchecked(crate::__risc0::SECP256R1_EQUATION_B_LE);
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    fn from_u32_words_le(words: [u32; 8]) -> FieldElement {
+        FieldElement::from_words_le(words)
+    }
 }

--- a/p256/src/arithmetic.rs
+++ b/p256/src/arithmetic.rs
@@ -32,11 +32,40 @@ impl PrimeCurveArithmetic for NistP256 {
 }
 
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-use primeorder::__risc0::FieldElement256;
+use primeorder::{__risc0::FieldElement256, PrimeCurveParams256};
 
 /// Adapted from [NIST SP 800-186] § G.1.2: Curve P-256.
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+impl PrimeCurveParams for NistP256 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    /// a = -3
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
+
+    const EQUATION_B: FieldElement =
+        FieldElement::from_hex("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b");
+
+    /// Base point of P-256.
+    ///
+    /// Defined in NIST SP 800-186 § G.1.2:
+    ///
+    /// ```text
+    /// Gₓ = 6b17d1f2 e12c4247 f8bce6e5 63a440f2 77037d81 2deb33a0 f4a13945 d898c296
+    /// Gᵧ = 4fe342e2 fe1a7f9b 8ee7eb4a 7c0f9e16 2bce3357 6b315ece cbb64068 37bf51f5
+    /// ```
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296"),
+        FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
+    );
+}
+
+/// Adapted from [NIST SP 800-186] § G.1.2: Curve P-256.
+///
+/// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 impl PrimeCurveParams for NistP256 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
@@ -60,21 +89,41 @@ impl PrimeCurveParams for NistP256 {
         FieldElement::from_hex("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"),
     );
 
-    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-    const PRIME_LE_WORDS: [u32; 8] = crate::__risc0::SECP256R1_PRIME;
+    fn zkvm_mul(
+        point: &primeorder::ProjectivePoint<Self>,
+        scalar: &elliptic_curve::Scalar<Self>,
+    ) -> primeorder::ProjectivePoint<Self> {
+        primeorder::__risc0::ec_impl::mul(point, scalar)
+    }
 
-    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    fn zkvm_to_affine(
+        point: &primeorder::ProjectivePoint<Self>,
+    ) -> primeorder::AffinePoint<Self> {
+        primeorder::__risc0::zkvm_to_affine_impl_256(point)
+    }
+
+    fn zkvm_decompress(
+        x_bytes: &primeorder::FieldBytes<Self>,
+        y_is_odd: elliptic_curve::subtle::Choice,
+    ) -> elliptic_curve::subtle::CtOption<primeorder::AffinePoint<Self>> {
+        primeorder::__risc0::zkvm_decompress_impl_256(x_bytes, y_is_odd)
+    }
+}
+
+/// 256-bit zkvm-specific constants and helpers.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl primeorder::PrimeCurveParams256 for NistP256 {
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
+
+    const PRIME_LE_WORDS: [u32; 8] = crate::__risc0::SECP256R1_PRIME;
     const ORDER_LE_WORDS: [u32; 8] = crate::__risc0::SECP256R1_ORDER;
 
-    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
     const EQUATION_A_LE: FieldElement256<NistP256> =
         FieldElement256::new_unchecked(crate::__risc0::SECP256R1_EQUATION_A_LE);
 
-    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
     const EQUATION_B_LE: FieldElement256<NistP256> =
         FieldElement256::new_unchecked(crate::__risc0::SECP256R1_EQUATION_B_LE);
 
-    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
     fn from_u32_words_le(words: [u32; 8]) -> FieldElement {
         FieldElement::from_words_le(words)
     }

--- a/p256/src/arithmetic/field.rs
+++ b/p256/src/arithmetic/field.rs
@@ -30,6 +30,14 @@ pub const MODULUS: U256 = U256::from_be_hex(MODULUS_HEX);
 const R_2: U256 =
     U256::from_be_hex("00000004fffffffdfffffffffffffffefffffffbffffffff0000000000000003");
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use primeorder::__risc0::FieldElement256;
+
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+const R_2_LE: FieldElement256<NistP256> = FieldElement256::new_unchecked([
+    0x00000001, 0x00000000, 0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFE, 0x00000000,
+]);
+
 /// An element in the finite field modulo p = 2^{224}(2^{32} − 1) + 2^{192} + 2^{96} − 1.
 ///
 /// The internal representation is in little-endian order. Elements are always in
@@ -54,8 +62,56 @@ primeorder::impl_mont_field_element!(
 );
 
 impl FieldElement {
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub(crate) fn from_words_le(fe: [u32; 8]) -> Self {
+        let fe = FieldElement256::new_unchecked(fe);
+
+        // Convert to montgomery form with aR mod p
+        let mut mont = FieldElement256::default();
+
+        // This mul will check if the result is within the modulus.
+        fe.mul(&R_2_LE, &mut mont);
+
+        let uint = U256::from_le_slice(bytemuck::cast_slice::<u32, u8>(&mont.data));
+
+        Self(uint)
+    }
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub(crate) fn to_words_le(&self) -> [u32; 8] {
+        use crate::elliptic_curve::bigint::Encoding;
+        // NOTE: this from mont conversion could be accelerated, but it's very little cycles.
+        let canonical = self.to_canonical();
+        let input = canonical.to_le_bytes();
+        let array = bytemuck::cast::<_, [u32; 8]>(input);
+
+        array
+    }
+
     /// Returns the multiplicative inverse of self, if self is non-zero.
     pub fn invert(&self) -> CtOption<Self> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            use crate::elliptic_curve::bigint::Encoding;
+
+            // NOTE: This is not a constant time operation, as inverting zero in the zkvm is not
+            // possible as it will panic in the host.
+            if self.is_zero().into() {
+                return CtOption::new(FieldElement::ZERO, Choice::from(0));
+            } else {
+                let input_words = self.to_words_le();
+                let mut output = [0u32; 8];
+                risc0_bigint2::field::modinv_256(
+                    &input_words,
+                    &crate::__risc0::SECP256R1_PRIME,
+                    &mut output,
+                );
+                let element = FieldElement::from_words_le(output);
+                return CtOption::new(element, Choice::from(1));
+            }
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         CtOption::new(self.invert_unchecked(), !self.is_zero())
     }
 
@@ -63,6 +119,9 @@ impl FieldElement {
     ///
     /// Does not check that self is non-zero.
     const fn invert_unchecked(&self) -> Self {
+        // NOTE: It is fine that the internal invert function is not overriden for the zkvm, as this
+        // is only called in compile time constants given `invert` is overridden.
+
         // We need to find b such that b * a ≡ 1 mod p. As we are in a prime
         // field, we can apply Fermat's Little Theorem:
         //
@@ -169,6 +228,7 @@ mod tests {
         impl_field_identity_tests, impl_field_invert_tests, impl_field_sqrt_tests,
         impl_primefield_tests,
     };
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::{num, prelude::*};
 
     /// t = (modulus - 1) >> S
@@ -263,6 +323,7 @@ mod tests {
         assert_eq!(two.pow_vartime(&[2, 0, 0, 0]), four);
     }
 
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     proptest! {
         /// This checks behaviour well within the field ranges, because it doesn't set the
         /// highest limb.

--- a/p256/src/arithmetic/field/field32.rs
+++ b/p256/src/arithmetic/field/field32.rs
@@ -9,7 +9,6 @@ use crate::arithmetic::util::{adc, mac, sbb};
 pub type Fe = [u32; 8];
 
 /// Translate a field element out of the Montgomery domain.
-#[inline]
 pub const fn fe_from_montgomery(w: &Fe) -> Fe {
     let w = fe32_to_fe64(w);
     montgomery_reduce(&[w[0], w[1], w[2], w[3], 0, 0, 0, 0])

--- a/p256/src/arithmetic/hash2curve.rs
+++ b/p256/src/arithmetic/hash2curve.rs
@@ -108,6 +108,7 @@ mod tests {
         Curve, Field,
     };
     use hex_literal::hex;
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     use proptest::{num::u64::ANY, prelude::ProptestConfig, proptest};
     use sha2::Sha256;
 
@@ -289,6 +290,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     fn from_okm_fuzz() {
         let mut wide_order = GenericArray::default();
         wide_order[16..].copy_from_slice(&NistP256::ORDER.to_be_byte_array());

--- a/p256/src/arithmetic/scalar.rs
+++ b/p256/src/arithmetic/scalar.rs
@@ -131,6 +131,30 @@ impl Scalar {
 
     /// Returns the multiplicative inverse of self, if self is non-zero
     pub fn invert(&self) -> CtOption<Self> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            use crate::elliptic_curve::bigint::Encoding;
+
+            // NOTE: This is not a constant time operation, as inverting zero in the zkvm is not
+            // possible as it will panic in the host.
+            if self.is_zero().into() {
+                return CtOption::new(Scalar::ZERO, Choice::from(0));
+            } else {
+                let input = self.0.to_le_bytes();
+                let input_words = bytemuck::cast::<_, [u32; 8]>(input);
+                let mut output = [0u32; 8];
+                risc0_bigint2::field::modinv_256(
+                    &input_words,
+                    &crate::__risc0::SECP256R1_ORDER,
+                    &mut output,
+                );
+                let bytes = bytemuck::cast_slice::<u32, u8>(&output);
+                let res = Scalar(U256::from_le_slice(bytes));
+                CtOption::new(res, Choice::from(1))
+            }
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         CtOption::new(self.invert_unchecked(), !self.is_zero())
     }
 
@@ -363,6 +387,11 @@ impl Invert for Scalar {
     /// sidechannels.
     #[allow(non_snake_case)]
     fn invert_vartime(&self) -> CtOption<Self> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return self.invert();
+        }
+
         let mut u = *self;
         let mut v = Self(MODULUS);
         let mut A = Self::ONE;

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -29,6 +29,10 @@
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+#[path = "risc0.rs"]
+mod __risc0;
+
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
 

--- a/p256/src/risc0.rs
+++ b/p256/src/risc0.rs
@@ -1,0 +1,31 @@
+use risc0_bigint2::ec::{Curve, WeierstrassCurve, EC_256_WIDTH_WORDS};
+
+/// The secp256r1 curve's prime field characteristic
+pub(crate) const SECP256R1_PRIME: [u32; EC_256_WIDTH_WORDS] = [
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000001, 0xFFFFFFFF,
+];
+
+/// The secp256r1 curve's order
+pub(crate) const SECP256R1_ORDER: [u32; EC_256_WIDTH_WORDS] = [
+    0xFC632551, 0xF3B9CAC2, 0xA7179E84, 0xBCE6FAAD, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF,
+];
+
+pub(crate) const SECP256R1_EQUATION_A_LE: [u32; EC_256_WIDTH_WORDS] = [
+    0xFFFFFFFC, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000, 0x00000001, 0xFFFFFFFF,
+];
+
+pub(crate) const SECP256R1_EQUATION_B_LE: [u32; EC_256_WIDTH_WORDS] = [
+    0x27D2604B, 0x3BCE3C3E, 0xCC53B0F6, 0x651D06B0, 0x769886BC, 0xB3EBBD55, 0xAA3A93E7, 0x5AC635D8,
+];
+
+const SECP256R1_CURVE: &WeierstrassCurve<EC_256_WIDTH_WORDS> =
+    &WeierstrassCurve::<EC_256_WIDTH_WORDS>::new(
+        SECP256R1_PRIME,
+        // Curve parameter a = -3 (represented mod p)
+        SECP256R1_EQUATION_A_LE,
+        SECP256R1_EQUATION_B_LE,
+    );
+
+impl Curve<EC_256_WIDTH_WORDS> for crate::NistP256 {
+    const CURVE: &'static WeierstrassCurve<EC_256_WIDTH_WORDS> = SECP256R1_CURVE;
+}

--- a/p256/tests/ecdsa.rs
+++ b/p256/tests/ecdsa.rs
@@ -1,7 +1,6 @@
 //! ECDSA tests.
 
-#![cfg(feature = "arithmetic")]
-
+#![cfg(all(feature = "arithmetic", not(all(target_os = "zkvm", target_arch = "riscv32"))))]
 use elliptic_curve::ops::Reduce;
 use p256::{
     ecdsa::{SigningKey, VerifyingKey},

--- a/p256/tests/scalar.rs
+++ b/p256/tests/scalar.rs
@@ -1,6 +1,6 @@
 //! Scalar arithmetic tests.
 
-#![cfg(feature = "arithmetic")]
+#![cfg(all(feature = "arithmetic", not(all(target_os = "zkvm", target_arch = "riscv32"))))]
 
 use elliptic_curve::ops::{Invert, Reduce};
 use p256::{Scalar, U256};

--- a/p384/Cargo.toml
+++ b/p384/Cargo.toml
@@ -26,6 +26,10 @@ primeorder = { version = "0.13.1", optional = true, path = "../primeorder" }
 serdect = { version = "0.2", optional = true, default-features = false }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+bytemuck = "1"
+risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
+
 [dev-dependencies]
 blobby = "0.3"
 criterion = "0.4"

--- a/p384/src/arithmetic.rs
+++ b/p384/src/arithmetic.rs
@@ -30,9 +30,13 @@ impl PrimeCurveArithmetic for NistP384 {
     type CurveGroup = ProjectivePoint;
 }
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use primeorder::__risc0::FieldElement384;
+
 /// Adapted from [NIST SP 800-186] § G.1.3: Curve P-384.
 ///
 /// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 impl PrimeCurveParams for NistP384 {
     type FieldElement = FieldElement;
     type PointArithmetic = point_arithmetic::EquationAIsMinusThree;
@@ -58,4 +62,74 @@ impl PrimeCurveParams for NistP384 {
         FieldElement::from_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
         FieldElement::from_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
     );
+}
+
+/// Adapted from [NIST SP 800-186] § G.1.3: Curve P-384.
+///
+/// [NIST SP 800-186]: https://csrc.nist.gov/publications/detail/sp/800-186/final
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl PrimeCurveParams for NistP384 {
+    type FieldElement = FieldElement;
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree384;
+
+    /// a = -3 (0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffc)
+    const EQUATION_A: FieldElement = FieldElement::from_u64(3).neg();
+
+    /// b = b3312fa7 e23ee7e4 988e056b e3f82d19 181d9c6e fe814112
+    ///     0314088f 5013875a c656398d 8a2ed19d 2a85c8ed d3ec2aef
+    const EQUATION_B: FieldElement = FieldElement::from_hex("b3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef");
+
+    /// Base point of P-384.
+    ///
+    /// Defined in NIST SP 800-186 § G.1.3: Curve P-384.
+    ///
+    /// ```text
+    /// Gₓ = aa87ca22 be8b0537 8eb1c71e f320ad74 6e1d3b62 8ba79b98
+    ///      59f741e0 82542a38 5502f25d bf55296c 3a545e38 72760ab7
+    /// Gᵧ = 3617de4a 96262c6f 5d9e98bf 9292dc29 f8f41dbd 289a147c
+    ///      e9da3113 b5f0b8c0 0a60b1ce 1d7e819d 7a431d7c 90ea0e5f
+    /// ```
+    const GENERATOR: (FieldElement, FieldElement) = (
+        FieldElement::from_hex("aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7"),
+        FieldElement::from_hex("3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
+    );
+
+    fn zkvm_mul(
+        point: &primeorder::ProjectivePoint<Self>,
+        scalar: &elliptic_curve::Scalar<Self>,
+    ) -> primeorder::ProjectivePoint<Self> {
+        primeorder::__risc0::ec_impl_384::mul(point, scalar)
+    }
+
+    fn zkvm_to_affine(
+        point: &primeorder::ProjectivePoint<Self>,
+    ) -> primeorder::AffinePoint<Self> {
+        primeorder::__risc0::zkvm_to_affine_impl_384(point)
+    }
+
+    fn zkvm_decompress(
+        x_bytes: &primeorder::FieldBytes<Self>,
+        y_is_odd: elliptic_curve::subtle::Choice,
+    ) -> elliptic_curve::subtle::CtOption<primeorder::AffinePoint<Self>> {
+        primeorder::__risc0::zkvm_decompress_impl_384(x_bytes, y_is_odd)
+    }
+}
+
+/// 384-bit zkvm-specific constants and helpers.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl primeorder::PrimeCurveParams384 for NistP384 {
+    type PointArithmetic = point_arithmetic::EquationAIsMinusThree384;
+
+    const PRIME_LE_WORDS: [u32; 12] = crate::__risc0::SECP384R1_PRIME;
+    const ORDER_LE_WORDS: [u32; 12] = crate::__risc0::SECP384R1_ORDER;
+
+    const EQUATION_A_LE: FieldElement384<NistP384> =
+        FieldElement384::new_unchecked(crate::__risc0::SECP384R1_EQUATION_A_LE);
+
+    const EQUATION_B_LE: FieldElement384<NistP384> =
+        FieldElement384::new_unchecked(crate::__risc0::SECP384R1_EQUATION_B_LE);
+
+    fn from_u32_words_le(words: [u32; 12]) -> FieldElement {
+        FieldElement::from_words_le(words)
+    }
 }

--- a/p384/src/arithmetic/field.rs
+++ b/p384/src/arithmetic/field.rs
@@ -41,6 +41,18 @@ use primeorder::impl_bernstein_yang_invert;
 /// p = 2^{384} − 2^{128} − 2^{96} + 2^{32} − 1
 pub(crate) const MODULUS: U384 = U384::from_be_hex(FieldElement::MODULUS);
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use primeorder::__risc0::FieldElement384;
+
+/// R = 2^384 mod p (for Montgomery conversion via standard modular multiplication)
+/// When multiplied with canonical value x: x * R mod p gives Montgomery form
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+const R_MOD_P_LE: FieldElement384<NistP384> = FieldElement384::new_unchecked([
+    0x00000001, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000,
+    0x00000001, 0x00000000, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000,
+]);
+
 /// Element of the secp384r1 base field used for curve coordinates.
 #[derive(Clone, Copy)]
 pub struct FieldElement(pub(super) U384);
@@ -62,6 +74,35 @@ primeorder::impl_mont_field_element!(
 );
 
 impl FieldElement {
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub(crate) fn from_words_le(fe: [u32; 12]) -> Self {
+        let fe = FieldElement384::<NistP384>::new_unchecked(fe);
+
+        // Convert to montgomery form with aR mod p
+        let mut mont = FieldElement384::<NistP384>::default();
+
+        // Multiply by R to convert to Montgomery form (standard modular multiplication)
+        risc0_bigint2::field::modmul_384(
+            &fe.data,
+            &R_MOD_P_LE.data,
+            &crate::__risc0::SECP384R1_PRIME,
+            &mut mont.data,
+        );
+
+        let uint = U384::from_le_slice(bytemuck::cast_slice::<u32, u8>(&mont.data));
+
+        Self(uint)
+    }
+
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub(crate) fn to_words_le(&self) -> [u32; 12] {
+        use elliptic_curve::bigint::Encoding;
+        // Convert from Montgomery to canonical form
+        let canonical = self.to_canonical();
+        let input = canonical.to_le_bytes();
+        bytemuck::cast::<_, [u32; 12]>(input)
+    }
+
     /// Compute [`FieldElement`] inversion: `1 / self`.
     pub fn invert(&self) -> CtOption<Self> {
         CtOption::new(self.invert_unchecked(), !self.is_zero())

--- a/p384/src/arithmetic/scalar.rs
+++ b/p384/src/arithmetic/scalar.rs
@@ -100,6 +100,33 @@ primeorder::impl_mont_field_element!(
 impl Scalar {
     /// Compute [`Scalar`] inversion: `1 / self`.
     pub fn invert(&self) -> CtOption<Self> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            use elliptic_curve::bigint::Encoding;
+
+            // NOTE: This is not a constant time operation, as inverting zero in the zkvm is not
+            // possible as it will panic in the host.
+            if self.is_zero().into() {
+                return CtOption::new(Scalar::ZERO, Choice::from(0));
+            } else {
+                // Convert from Montgomery form to canonical form
+                let canonical = self.to_canonical();
+                let input = canonical.to_le_bytes();
+                let input_words = bytemuck::cast::<_, [u32; 12]>(input);
+                let mut output = [0u32; 12];
+                risc0_bigint2::field::modinv_384(
+                    &input_words,
+                    &crate::__risc0::SECP384R1_ORDER,
+                    &mut output,
+                );
+                let bytes = bytemuck::cast_slice::<u32, u8>(&output);
+                // Convert result back to Montgomery form
+                let res = Scalar::from_uint_unchecked(U384::from_le_slice(bytes));
+                return CtOption::new(res, Choice::from(1));
+            }
+        }
+
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         CtOption::new(self.invert_unchecked(), !self.is_zero())
     }
 

--- a/p384/src/lib.rs
+++ b/p384/src/lib.rs
@@ -22,6 +22,10 @@
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
 
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+#[path = "risc0.rs"]
+mod __risc0;
+
 #[cfg(feature = "ecdh")]
 pub mod ecdh;
 

--- a/p384/src/risc0.rs
+++ b/p384/src/risc0.rs
@@ -1,0 +1,41 @@
+use risc0_bigint2::ec::{Curve, WeierstrassCurve, EC_384_WIDTH_WORDS};
+
+/// The secp384r1 curve's prime field characteristic
+/// p = 2^384 − 2^128 − 2^96 + 2^32 − 1
+pub(crate) const SECP384R1_PRIME: [u32; EC_384_WIDTH_WORDS] = [
+    0xFFFFFFFF, 0x00000000, 0x00000000, 0xFFFFFFFF,
+    0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+];
+
+/// The secp384r1 curve's order
+pub(crate) const SECP384R1_ORDER: [u32; EC_384_WIDTH_WORDS] = [
+    0xCCC52973, 0xECEC196A, 0x48B0A77A, 0x581A0DB2,
+    0xF4372DDF, 0xC7634D81, 0xFFFFFFFF, 0xFFFFFFFF,
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+];
+
+/// Coefficient a = -3 (represented mod p) in little-endian words
+pub(crate) const SECP384R1_EQUATION_A_LE: [u32; EC_384_WIDTH_WORDS] = [
+    0xFFFFFFFC, 0x00000000, 0x00000000, 0xFFFFFFFF,
+    0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+];
+
+/// Coefficient b in little-endian words
+pub(crate) const SECP384R1_EQUATION_B_LE: [u32; EC_384_WIDTH_WORDS] = [
+    0xD3EC2AEF, 0x2A85C8ED, 0x8A2ED19D, 0xC656398D,
+    0x5013875A, 0x0314088F, 0xFE814112, 0x181D9C6E,
+    0xE3F82D19, 0x988E056B, 0xE23EE7E4, 0xB3312FA7,
+];
+
+const SECP384R1_CURVE: &WeierstrassCurve<EC_384_WIDTH_WORDS> =
+    &WeierstrassCurve::<EC_384_WIDTH_WORDS>::new(
+        SECP384R1_PRIME,
+        SECP384R1_EQUATION_A_LE,
+        SECP384R1_EQUATION_B_LE,
+    );
+
+impl Curve<EC_384_WIDTH_WORDS> for crate::NistP384 {
+    const CURVE: &'static WeierstrassCurve<EC_384_WIDTH_WORDS> = SECP384R1_CURVE;
+}

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -22,6 +22,10 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["arit
 # optional dependencies
 serdect = { version = "0.2", optional = true, default-features = false }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+bytemuck = "1"
+
 [features]
 std = ["elliptic-curve/std"]
 

--- a/primeorder/Cargo.toml
+++ b/primeorder/Cargo.toml
@@ -23,7 +23,7 @@ elliptic-curve = { version = "0.13", default-features = false, features = ["arit
 serdect = { version = "0.2", optional = true, default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
+risc0-bigint2 = { version = "1.4.0", features = ["unstable"] }
 bytemuck = "1"
 
 [features]

--- a/primeorder/src/affine.rs
+++ b/primeorder/src/affine.rs
@@ -133,51 +133,7 @@ where
     fn decompress(x_bytes: &FieldBytes<C>, y_is_odd: Choice) -> CtOption<Self> {
         #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
         {
-            use crate::__risc0::FieldElement256;
-
-            // Note: buffers are kept separate for each OP as the result pointer cannot equal one
-            // of the input pointers.
-            let mut scratch = FieldElement256::<C>::default();
-            let mut acc = FieldElement256::<C>::default();
-            let mut scratch_1 = FieldElement256::<C>::from(x_bytes);
-
-            // x checked to be in the field.
-            C::FieldElement::from_repr(*x_bytes).and_then(|x| {
-                // x * &x * &x
-                scratch_1.mul_unchecked(&scratch_1, &mut scratch);
-                scratch.mul_unchecked(&scratch_1, &mut acc);
-
-                // + &(C::EQUATION_A * &x)
-                scratch_1.mul_unchecked(&C::EQUATION_A_LE, &mut scratch);
-                // Can re-use x as a buffer, no longer needed.
-                scratch.add_unchecked(&acc, &mut scratch_1);
-
-                // + &C::EQUATION_B
-                scratch_1.add_unchecked(&C::EQUATION_B_LE, &mut scratch);
-
-                // Sqrt implementation. Not separated into another function to allow
-                // re-using buffers.
-                scratch.sqrt_unchecked(&mut scratch_1, &mut acc);
-
-                // Check that the square root is correct.
-                acc.square(&mut scratch_1);
-
-                let sqrt = CtOption::new(acc, Choice::from(scratch_1.eq(&scratch) as u8));
-
-                // Checked that the result is within the field.
-                sqrt.and_then(|sqrt| {
-                    C::FieldElement::from_repr(sqrt.into()).map(|beta| {
-                        let y = C::FieldElement::conditional_select(
-                            // TODO this neg can be accelerated too
-                            &-beta,
-                            &beta,
-                            beta.is_odd().ct_eq(&y_is_odd),
-                        );
-
-                        Self { x, y, infinity: 0 }
-                    })
-                })
-            })
+            return C::zkvm_decompress(x_bytes, y_is_odd);
         }
 
         #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]

--- a/primeorder/src/field.rs
+++ b/primeorder/src/field.rs
@@ -456,7 +456,6 @@ macro_rules! impl_field_op {
         impl ::core::ops::$op for $fe {
             type Output = $fe;
 
-            #[inline]
             fn $op_fn(self, rhs: $fe) -> $fe {
                 $fe($func(self.as_ref(), rhs.as_ref()).into())
             }
@@ -465,7 +464,6 @@ macro_rules! impl_field_op {
         impl ::core::ops::$op<&$fe> for $fe {
             type Output = $fe;
 
-            #[inline]
             fn $op_fn(self, rhs: &$fe) -> $fe {
                 $fe($func(self.as_ref(), rhs.as_ref()).into())
             }
@@ -474,7 +472,6 @@ macro_rules! impl_field_op {
         impl ::core::ops::$op<&$fe> for &$fe {
             type Output = $fe;
 
-            #[inline]
             fn $op_fn(self, rhs: &$fe) -> $fe {
                 $fe($func(self.as_ref(), rhs.as_ref()).into())
             }

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -16,6 +16,11 @@ mod dev;
 mod field;
 mod projective;
 
+/// WARNING: This is not part of the public API of the crate, and will not follow semver guarantees.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+#[path = "risc0.rs"]
+pub mod __risc0;
+
 pub use crate::{affine::AffinePoint, projective::ProjectivePoint};
 pub use elliptic_curve::{self, point::Double, Field, FieldBytes, PrimeCurve, PrimeField};
 
@@ -23,6 +28,7 @@ use elliptic_curve::CurveArithmetic;
 
 /// Parameters for elliptic curves of prime order which can be described by the
 /// short Weierstrass equation.
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 pub trait PrimeCurveParams:
     PrimeCurve
     + CurveArithmetic
@@ -43,4 +49,51 @@ pub trait PrimeCurveParams:
 
     /// Generator point's affine coordinates: (x, y).
     const GENERATOR: (Self::FieldElement, Self::FieldElement);
+}
+
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use risc0_bigint2::ec;
+
+/// Parameters for elliptic curves of prime order which can be described by the
+/// short Weierstrass equation.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub trait PrimeCurveParams:
+    // TODO this doesn't support different bit widths
+    ec::Curve<{ec::EC_256_WIDTH_WORDS}> + 
+    Sized +
+    PrimeCurve
+    + CurveArithmetic
+    + CurveArithmetic<AffinePoint = AffinePoint<Self>>
+    + CurveArithmetic<ProjectivePoint = ProjectivePoint<Self>>
+{
+    /// Base field element type.
+    type FieldElement: PrimeField<Repr = FieldBytes<Self>>;
+
+    /// [Point arithmetic](point_arithmetic) implementation, might be optimized for this specific curve
+    type PointArithmetic: point_arithmetic::PointArithmetic<Self>;
+
+    /// Coefficient `a` in the curve equation.
+    const EQUATION_A: Self::FieldElement;
+
+    /// Coefficient `b` in the curve equation.
+    const EQUATION_B: Self::FieldElement;
+
+    /// Generator point's affine coordinates: (x, y).
+    const GENERATOR: (Self::FieldElement, Self::FieldElement);
+
+    ///  Curve prime in little-endian words to be compatible with risc0 expected layout.
+    const PRIME_LE_WORDS: [u32; 8];
+
+    /// Order of the curve in little-endian words to be compatible with risc0 expected layout.
+    const ORDER_LE_WORDS: [u32; 8];
+
+    /// Coefficient `a` in the curve equation in little-endian words to be compatible with risc0
+    /// expected layout.
+    const EQUATION_A_LE: __risc0::FieldElement256<Self>;
+
+    /// Coefficient `b` in the curve equation in little-endian words to be compatible with risc0
+    /// expected layout.
+    const EQUATION_B_LE: __risc0::FieldElement256<Self>;
+
+    fn from_u32_words_le(words: [u32; 8]) -> Self::FieldElement;
 }

--- a/primeorder/src/lib.rs
+++ b/primeorder/src/lib.rs
@@ -51,6 +51,15 @@ pub trait PrimeCurveParams:
     const GENERATOR: (Self::FieldElement, Self::FieldElement);
 }
 
+/// Parameters for 384-bit elliptic curves (non-zkvm version).
+/// Alias for PrimeCurveParams since they're identical on non-zkvm.
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+pub trait PrimeCurveParams384: PrimeCurveParams {}
+
+/// Blanket implementation: any PrimeCurveParams is also PrimeCurveParams384 on non-zkvm.
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+impl<T: PrimeCurveParams> PrimeCurveParams384 for T {}
+
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 use risc0_bigint2::ec;
 
@@ -58,8 +67,6 @@ use risc0_bigint2::ec;
 /// short Weierstrass equation.
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 pub trait PrimeCurveParams:
-    // TODO this doesn't support different bit widths
-    ec::Curve<{ec::EC_256_WIDTH_WORDS}> + 
     Sized +
     PrimeCurve
     + CurveArithmetic
@@ -81,7 +88,26 @@ pub trait PrimeCurveParams:
     /// Generator point's affine coordinates: (x, y).
     const GENERATOR: (Self::FieldElement, Self::FieldElement);
 
-    ///  Curve prime in little-endian words to be compatible with risc0 expected layout.
+    /// Scalar multiplication for zkvm (accelerated). Curves implement this based on their width.
+    fn zkvm_mul(point: &ProjectivePoint<Self>, scalar: &elliptic_curve::Scalar<Self>) -> ProjectivePoint<Self>;
+
+    /// Convert projective to affine for zkvm (accelerated). Curves implement this based on their width.
+    fn zkvm_to_affine(point: &ProjectivePoint<Self>) -> AffinePoint<Self>;
+
+    /// Decompress point for zkvm (accelerated). Curves implement this based on their width.
+    fn zkvm_decompress(x_bytes: &FieldBytes<Self>, y_is_odd: elliptic_curve::subtle::Choice) -> elliptic_curve::subtle::CtOption<AffinePoint<Self>>;
+}
+
+/// Parameters for 256-bit elliptic curves on zkvm.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub trait PrimeCurveParams256:
+    PrimeCurveParams +
+    ec::Curve<{ec::EC_256_WIDTH_WORDS}>
+{
+    /// [Point arithmetic](point_arithmetic) implementation
+    type PointArithmetic: point_arithmetic::PointArithmetic<Self>;
+
+    /// Curve prime in little-endian words to be compatible with risc0 expected layout.
     const PRIME_LE_WORDS: [u32; 8];
 
     /// Order of the curve in little-endian words to be compatible with risc0 expected layout.
@@ -95,5 +121,33 @@ pub trait PrimeCurveParams:
     /// expected layout.
     const EQUATION_B_LE: __risc0::FieldElement256<Self>;
 
+    /// Convert from little-endian words to field element.
     fn from_u32_words_le(words: [u32; 8]) -> Self::FieldElement;
+}
+
+/// Parameters for 384-bit elliptic curves on zkvm.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub trait PrimeCurveParams384:
+    PrimeCurveParams +
+    ec::Curve<{ec::EC_384_WIDTH_WORDS}>
+{
+    /// [Point arithmetic](point_arithmetic) implementation
+    type PointArithmetic: point_arithmetic::PointArithmetic384<Self>;
+
+    /// Curve prime in little-endian words to be compatible with risc0 expected layout.
+    const PRIME_LE_WORDS: [u32; 12];
+
+    /// Order of the curve in little-endian words to be compatible with risc0 expected layout.
+    const ORDER_LE_WORDS: [u32; 12];
+
+    /// Coefficient `a` in the curve equation in little-endian words to be compatible with risc0
+    /// expected layout.
+    const EQUATION_A_LE: __risc0::FieldElement384<Self>;
+
+    /// Coefficient `b` in the curve equation in little-endian words to be compatible with risc0
+    /// expected layout.
+    const EQUATION_B_LE: __risc0::FieldElement384<Self>;
+
+    /// Convert from little-endian words to field element.
+    fn from_u32_words_le(words: [u32; 12]) -> Self::FieldElement;
 }

--- a/primeorder/src/point_arithmetic.rs
+++ b/primeorder/src/point_arithmetic.rs
@@ -42,6 +42,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::add(lhs, rhs);
+        }
         let b3 = C::FieldElement::from(3) * C::EQUATION_B;
 
         let t0 = lhs.x * rhs.x; // 1
@@ -100,6 +104,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::add_mixed(lhs, rhs);
+        }
         let b3 = C::EQUATION_B * C::FieldElement::from(3);
 
         let t0 = lhs.x * rhs.x; // 1
@@ -153,6 +161,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::double(point);
+        }
         let b3 = C::EQUATION_B * C::FieldElement::from(3);
 
         let t0 = point.x * point.x; // 1
@@ -207,6 +219,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::add(lhs, rhs);
+        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),
@@ -245,6 +261,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::add_mixed(lhs, rhs);
+        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),
@@ -284,6 +304,10 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            return crate::__risc0::ec_impl::double(point);
+        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),

--- a/primeorder/src/point_arithmetic.rs
+++ b/primeorder/src/point_arithmetic.rs
@@ -6,9 +6,13 @@
 use elliptic_curve::{subtle::ConditionallySelectable, Field};
 
 use crate::{AffinePoint, PrimeCurveParams, ProjectivePoint};
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+use crate::{PrimeCurveParams256, PrimeCurveParams384};
 
 mod sealed {
     use crate::{AffinePoint, PrimeCurveParams, ProjectivePoint};
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    use crate::PrimeCurveParams384;
 
     /// Elliptic point arithmetic implementation
     ///
@@ -24,15 +28,32 @@ mod sealed {
         /// Returns `point + point`
         fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C>;
     }
+
+    /// Elliptic point arithmetic implementation for 384-bit curves
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub trait PointArithmetic384<C: PrimeCurveParams384> {
+        /// Returns `lhs + rhs`
+        fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C>;
+
+        /// Returns `lhs + rhs`
+        fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C>;
+
+        /// Returns `point + point`
+        fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C>;
+    }
 }
 
 /// Allow crate-local visibility
 pub(crate) use sealed::PointArithmetic;
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub(crate) use sealed::PointArithmetic384;
 
 /// The 𝒂-coefficient of the short Weierstrass equation does not have specific
 /// properties which allow for an optimized implementation.
 pub struct EquationAIsGeneric {}
 
+/// Software fallback for non-zkvm targets
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     /// Implements complete addition for any curve
     ///
@@ -42,10 +63,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::add(lhs, rhs);
-        }
         let b3 = C::FieldElement::from(3) * C::EQUATION_B;
 
         let t0 = lhs.x * rhs.x; // 1
@@ -104,10 +121,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::add_mixed(lhs, rhs);
-        }
         let b3 = C::EQUATION_B * C::FieldElement::from(3);
 
         let t0 = lhs.x * rhs.x; // 1
@@ -161,10 +174,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::double(point);
-        }
         let b3 = C::EQUATION_B * C::FieldElement::from(3);
 
         let t0 = point.x * point.x; // 1
@@ -207,9 +216,27 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsGeneric {
     }
 }
 
+/// Accelerated implementation for zkvm targets (256-bit curves)
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl<C: PrimeCurveParams256> PointArithmetic<C> for EquationAIsGeneric {
+    fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::add(lhs, rhs)
+    }
+
+    fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::add_mixed(lhs, rhs)
+    }
+
+    fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::double(point)
+    }
+}
+
 /// The 𝒂-coefficient of the short Weierstrass equation is -3.
 pub struct EquationAIsMinusThree {}
 
+/// Software fallback for non-zkvm targets
+#[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     /// Implements complete addition for curves with `a = -3`
     ///
@@ -219,10 +246,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::add(lhs, rhs);
-        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),
@@ -261,10 +284,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::add_mixed(lhs, rhs);
-        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),
@@ -304,10 +323,6 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
     ///
     /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
-        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-        {
-            return crate::__risc0::ec_impl::double(point);
-        }
         debug_assert_eq!(
             C::EQUATION_A,
             -C::FieldElement::from(3),
@@ -338,5 +353,58 @@ impl<C: PrimeCurveParams> PointArithmetic<C> for EquationAIsMinusThree {
         let z = (yz2 * yy).double().double(); // 32, 33, 34
 
         ProjectivePoint { x, y, z }
+    }
+}
+
+/// Accelerated implementation for zkvm targets (256-bit curves)
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl<C: PrimeCurveParams256> PointArithmetic<C> for EquationAIsMinusThree {
+    fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::add(lhs, rhs)
+    }
+
+    fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::add_mixed(lhs, rhs)
+    }
+
+    fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl::double(point)
+    }
+}
+
+/// The 𝒂-coefficient of the short Weierstrass equation is -3 (384-bit curves).
+/// This implementation uses risc0-bigint2 EC acceleration.
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+pub struct EquationAIsMinusThree384 {}
+
+/// PointArithmetic impl for 384-bit curves (used by PrimeCurveParams::PointArithmetic)
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl<C: PrimeCurveParams384> PointArithmetic<C> for EquationAIsMinusThree384 {
+    fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::add(lhs, rhs)
+    }
+
+    fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::add_mixed(lhs, rhs)
+    }
+
+    fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::double(point)
+    }
+}
+
+/// PointArithmetic384 impl (used by PrimeCurveParams384::PointArithmetic)
+#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+impl<C: PrimeCurveParams384> PointArithmetic384<C> for EquationAIsMinusThree384 {
+    fn add(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::add(lhs, rhs)
+    }
+
+    fn add_mixed(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::add_mixed(lhs, rhs)
+    }
+
+    fn double(point: &ProjectivePoint<C>) -> ProjectivePoint<C> {
+        crate::__risc0::ec_impl_384::double(point)
     }
 }

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -65,12 +65,12 @@ where
             }
             let z = felt_to_u32_words_le::<C>(&self.z);
             let mut z_inv = [0u32; 8];
-            risc0_bigint2::field::modinv_256_unchecked(&z, &C::PRIME_LE_WORDS, &mut z_inv);
+            risc0_bigint2::field::unchecked::modinv_256(&z, &C::PRIME_LE_WORDS, &mut z_inv);
 
             let mut buffer = [0u32; 8];
             let x_buffer = felt_to_u32_words_le::<C>(&self.x);
             let y_buffer = felt_to_u32_words_le::<C>(&self.y);
-            risc0_bigint2::field::modmul_256_unchecked(
+            risc0_bigint2::field::unchecked::modmul_256(
                 &x_buffer,
                 &z_inv,
                 &C::PRIME_LE_WORDS,
@@ -79,7 +79,7 @@ where
 
             let x = C::from_u32_words_le(buffer);
 
-            risc0_bigint2::field::modmul_256_unchecked(
+            risc0_bigint2::field::unchecked::modmul_256(
                 &y_buffer,
                 &z_inv,
                 &C::PRIME_LE_WORDS,

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -57,6 +57,38 @@ where
 
     /// Returns the affine representation of this point, or `None` if it is the identity.
     pub fn to_affine(&self) -> AffinePoint<C> {
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            use crate::__risc0::felt_to_u32_words_le;
+            if self.z.is_zero().into() {
+                return AffinePoint::IDENTITY;
+            }
+            let z = felt_to_u32_words_le::<C>(&self.z);
+            let mut z_inv = [0u32; 8];
+            risc0_bigint2::field::modinv_256_unchecked(&z, &C::PRIME_LE_WORDS, &mut z_inv);
+
+            let mut buffer = [0u32; 8];
+            let x_buffer = felt_to_u32_words_le::<C>(&self.x);
+            let y_buffer = felt_to_u32_words_le::<C>(&self.y);
+            risc0_bigint2::field::modmul_256_unchecked(
+                &x_buffer,
+                &z_inv,
+                &C::PRIME_LE_WORDS,
+                &mut buffer,
+            );
+
+            let x = C::from_u32_words_le(buffer);
+
+            risc0_bigint2::field::modmul_256_unchecked(
+                &y_buffer,
+                &z_inv,
+                &C::PRIME_LE_WORDS,
+                &mut buffer,
+            );
+            let y = C::from_u32_words_le(buffer);
+            return AffinePoint { x, y, infinity: 0 };
+        }
+
         self.z
             .invert()
             .map(|zinv| AffinePoint {
@@ -101,46 +133,53 @@ where
     where
         Self: Double,
     {
-        let k = Into::<C::Uint>::into(*k).to_le_byte_array();
-
-        let mut pc = [Self::default(); 16];
-        pc[0] = Self::IDENTITY;
-        pc[1] = *self;
-
-        for i in 2..16 {
-            pc[i] = if i % 2 == 0 {
-                Double::double(&pc[i / 2])
-            } else {
-                pc[i - 1].add(self)
-            };
+        #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+        {
+            crate::__risc0::ec_impl::mul(self, k)
         }
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
+        {
+            let k = Into::<C::Uint>::into(*k).to_le_byte_array();
 
-        let mut q = Self::IDENTITY;
-        let mut pos = C::Uint::BITS - 4;
+            let mut pc = [Self::default(); 16];
+            pc[0] = Self::IDENTITY;
+            pc[1] = *self;
 
-        loop {
-            let slot = (k[pos >> 3] >> (pos & 7)) & 0xf;
-
-            let mut t = ProjectivePoint::IDENTITY;
-
-            for i in 1..16 {
-                t.conditional_assign(
-                    &pc[i],
-                    Choice::from(((slot as usize ^ i).wrapping_sub(1) >> 8) as u8 & 1),
-                );
+            for i in 2..16 {
+                pc[i] = if i % 2 == 0 {
+                    Double::double(&pc[i / 2])
+                } else {
+                    pc[i - 1].add(self)
+                };
             }
 
-            q = q.add(&t);
+            let mut q = Self::IDENTITY;
+            let mut pos = C::Uint::BITS - 4;
 
-            if pos == 0 {
-                break;
+            loop {
+                let slot = (k[pos >> 3] >> (pos & 7)) & 0xf;
+
+                let mut t = ProjectivePoint::IDENTITY;
+
+                for i in 1..16 {
+                    t.conditional_assign(
+                        &pc[i],
+                        Choice::from(((slot as usize ^ i).wrapping_sub(1) >> 8) as u8 & 1),
+                    );
+                }
+
+                q = q.add(&t);
+
+                if pos == 0 {
+                    break;
+                }
+
+                q = Double::double(&Double::double(&Double::double(&Double::double(&q))));
+                pos -= 4;
             }
 
-            q = Double::double(&Double::double(&Double::double(&Double::double(&q))));
-            pos -= 4;
+            q
         }
-
-        q
     }
 }
 
@@ -332,6 +371,7 @@ where
     Self: Double,
     C: PrimeCurveParams,
 {
+    // TODO optimize impl for r0
 }
 
 impl<C> MulByGenerator for ProjectivePoint<C>

--- a/primeorder/src/projective.rs
+++ b/primeorder/src/projective.rs
@@ -59,36 +59,10 @@ where
     pub fn to_affine(&self) -> AffinePoint<C> {
         #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
         {
-            use crate::__risc0::felt_to_u32_words_le;
-            if self.z.is_zero().into() {
-                return AffinePoint::IDENTITY;
-            }
-            let z = felt_to_u32_words_le::<C>(&self.z);
-            let mut z_inv = [0u32; 8];
-            risc0_bigint2::field::unchecked::modinv_256(&z, &C::PRIME_LE_WORDS, &mut z_inv);
-
-            let mut buffer = [0u32; 8];
-            let x_buffer = felt_to_u32_words_le::<C>(&self.x);
-            let y_buffer = felt_to_u32_words_le::<C>(&self.y);
-            risc0_bigint2::field::unchecked::modmul_256(
-                &x_buffer,
-                &z_inv,
-                &C::PRIME_LE_WORDS,
-                &mut buffer,
-            );
-
-            let x = C::from_u32_words_le(buffer);
-
-            risc0_bigint2::field::unchecked::modmul_256(
-                &y_buffer,
-                &z_inv,
-                &C::PRIME_LE_WORDS,
-                &mut buffer,
-            );
-            let y = C::from_u32_words_le(buffer);
-            return AffinePoint { x, y, infinity: 0 };
+            return C::zkvm_to_affine(self);
         }
 
+        #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         self.z
             .invert()
             .map(|zinv| AffinePoint {
@@ -135,7 +109,7 @@ where
     {
         #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
         {
-            crate::__risc0::ec_impl::mul(self, k)
+            C::zkvm_mul(self, k)
         }
         #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
         {

--- a/primeorder/src/risc0.rs
+++ b/primeorder/src/risc0.rs
@@ -9,6 +9,8 @@ use elliptic_curve::{PrimeField, Scalar};
 use risc0_bigint2::ec;
 
 use crate::PrimeCurveParams;
+use crate::PrimeCurveParams256;
+use crate::PrimeCurveParams384;
 
 /// Representation of a field element in raw bytes form. This is not in montgomery form.
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
@@ -72,7 +74,7 @@ impl<C> FieldElement256<C> {
 
 impl<C> FieldElement256<C>
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
 {
     #[inline]
     pub fn mul_unchecked(&self, rhs: &Self, result: &mut Self) {
@@ -106,7 +108,7 @@ where
 
     /// Calculate the square root of the field element, using the provided buffer as scratch, and
     /// writing the result to the `result` parameter.
-    pub(crate) fn sqrt_unchecked(&self, scratch: &mut Self, result: &mut Self) {
+    pub fn sqrt_unchecked(&self, scratch: &mut Self, result: &mut Self) {
         // New buffers to keep temporary values.
         let mut scratch_1 = Self::default();
         let mut scratch_2 = Self::default();
@@ -183,7 +185,7 @@ where
     }
 
     /// Returns self^2 mod p
-    pub(crate) fn square(&self, result: &mut Self) {
+    pub fn square(&self, result: &mut Self) {
         self.mul_unchecked(self, result);
     }
 }
@@ -200,9 +202,9 @@ fn bytes_to_u32_words_le(bytes: &[u8]) -> [u32; 8] {
     words
 }
 
-pub(crate) fn felt_to_u32_words_le<C>(data: &C::FieldElement) -> [u32; 8]
+pub fn felt_to_u32_words_le<C>(data: &C::FieldElement) -> [u32; 8]
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
 {
     bytes_to_u32_words_le(data.to_repr().as_slice())
 }
@@ -210,7 +212,7 @@ where
 #[inline]
 fn affine_to_r0_affine<C>(affine: &AffinePoint<C>) -> ec::AffinePoint<8, C>
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
 {
     if bool::from(affine.is_identity()) {
         return ec::AffinePoint::IDENTITY;
@@ -221,17 +223,200 @@ where
     ec::AffinePoint::new_unchecked(x, y)
 }
 
-pub(crate) fn projective_to_affine<C>(p: &ProjectivePoint<C>) -> ec::AffinePoint<8, C>
+pub fn projective_to_affine<C>(p: &ProjectivePoint<C>) -> ec::AffinePoint<8, C>
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
 {
     let aff = p.to_affine();
     affine_to_r0_affine(&aff)
 }
 
-pub(crate) fn affine_to_projective<C>(affine: &ec::AffinePoint<8, C>) -> ProjectivePoint<C>
+/// Public helper for curves implementing zkvm_to_affine (256-bit).
+/// Converts projective point to affine using accelerated field inversion.
+pub fn zkvm_to_affine_impl_256<C>(point: &ProjectivePoint<C>) -> AffinePoint<C>
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
+{
+    use elliptic_curve::{Field, PrimeField};
+
+    if point.z.is_zero().into() {
+        return AffinePoint::IDENTITY;
+    }
+    let z = felt_to_u32_words_le::<C>(&point.z);
+    let mut z_inv = [0u32; 8];
+    risc0_bigint2::field::unchecked::modinv_256(&z, &C::PRIME_LE_WORDS, &mut z_inv);
+
+    let mut buffer = [0u32; 8];
+    let x_buffer = felt_to_u32_words_le::<C>(&point.x);
+    let y_buffer = felt_to_u32_words_le::<C>(&point.y);
+    risc0_bigint2::field::unchecked::modmul_256(
+        &x_buffer,
+        &z_inv,
+        &C::PRIME_LE_WORDS,
+        &mut buffer,
+    );
+
+    let x = C::from_u32_words_le(buffer);
+
+    risc0_bigint2::field::unchecked::modmul_256(
+        &y_buffer,
+        &z_inv,
+        &C::PRIME_LE_WORDS,
+        &mut buffer,
+    );
+    let y = C::from_u32_words_le(buffer);
+    AffinePoint { x, y, infinity: 0 }
+}
+
+/// Public helper for curves implementing zkvm_decompress (256-bit).
+/// Decompresses a point from its x-coordinate using accelerated field operations.
+pub fn zkvm_decompress_impl_256<C>(
+    x_bytes: &FieldBytes<C>,
+    y_is_odd: elliptic_curve::subtle::Choice,
+) -> elliptic_curve::subtle::CtOption<AffinePoint<C>>
+where
+    C: PrimeCurveParams256 + elliptic_curve::Curve<FieldBytesSize = elliptic_curve::consts::U32>,
+{
+    use elliptic_curve::subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
+
+    // Note: buffers are kept separate for each OP as the result pointer cannot equal one
+    // of the input pointers.
+    let mut scratch = FieldElement256::<C>::default();
+    let mut acc = FieldElement256::<C>::default();
+    let mut scratch_1 = FieldElement256::<C>::from(x_bytes);
+
+    // x checked to be in the field.
+    C::FieldElement::from_repr(*x_bytes).and_then(|x| {
+        // x * &x * &x
+        scratch_1.mul_unchecked(&scratch_1, &mut scratch);
+        scratch.mul_unchecked(&scratch_1, &mut acc);
+
+        // + &(C::EQUATION_A * &x)
+        scratch_1.mul_unchecked(&C::EQUATION_A_LE, &mut scratch);
+        // Can re-use x as a buffer, no longer needed.
+        scratch.add_unchecked(&acc, &mut scratch_1);
+
+        // + &C::EQUATION_B
+        scratch_1.add_unchecked(&C::EQUATION_B_LE, &mut scratch);
+
+        // Sqrt implementation. Not separated into another function to allow
+        // re-using buffers.
+        scratch.sqrt_unchecked(&mut scratch_1, &mut acc);
+
+        // Check that the square root is correct.
+        acc.square(&mut scratch_1);
+
+        let sqrt = CtOption::new(acc, elliptic_curve::subtle::Choice::from(scratch_1.eq(&scratch) as u8));
+
+        // Checked that the result is within the field.
+        sqrt.and_then(|sqrt| {
+            C::FieldElement::from_repr(sqrt.into()).map(|beta| {
+                let y = C::FieldElement::conditional_select(
+                    &-beta,
+                    &beta,
+                    beta.is_odd().ct_eq(&y_is_odd),
+                );
+
+                AffinePoint { x, y, infinity: 0 }
+            })
+        })
+    })
+}
+
+/// Public helper for curves implementing zkvm_to_affine (384-bit).
+/// Converts projective point to affine using accelerated field inversion.
+pub fn zkvm_to_affine_impl_384<C>(point: &ProjectivePoint<C>) -> AffinePoint<C>
+where
+    C: PrimeCurveParams384,
+{
+    use elliptic_curve::{Field, PrimeField};
+
+    if point.z.is_zero().into() {
+        return AffinePoint::IDENTITY;
+    }
+    let z = felt_to_u32_words_le_384::<C>(&point.z);
+    let mut z_inv = [0u32; 12];
+    risc0_bigint2::field::unchecked::modinv_384(&z, &C::PRIME_LE_WORDS, &mut z_inv);
+
+    let mut buffer = [0u32; 12];
+    let x_buffer = felt_to_u32_words_le_384::<C>(&point.x);
+    let y_buffer = felt_to_u32_words_le_384::<C>(&point.y);
+    risc0_bigint2::field::unchecked::modmul_384(
+        &x_buffer,
+        &z_inv,
+        &C::PRIME_LE_WORDS,
+        &mut buffer,
+    );
+
+    let x = C::from_u32_words_le(buffer);
+
+    risc0_bigint2::field::unchecked::modmul_384(
+        &y_buffer,
+        &z_inv,
+        &C::PRIME_LE_WORDS,
+        &mut buffer,
+    );
+    let y = C::from_u32_words_le(buffer);
+    AffinePoint { x, y, infinity: 0 }
+}
+
+/// Public helper for curves implementing zkvm_decompress (384-bit).
+/// Decompresses a point from its x-coordinate using accelerated field operations.
+pub fn zkvm_decompress_impl_384<C>(
+    x_bytes: &FieldBytes<C>,
+    y_is_odd: elliptic_curve::subtle::Choice,
+) -> elliptic_curve::subtle::CtOption<AffinePoint<C>>
+where
+    C: PrimeCurveParams384 + elliptic_curve::Curve<FieldBytesSize = elliptic_curve::consts::U48>,
+{
+    use elliptic_curve::subtle::{ConditionallySelectable, ConstantTimeEq, CtOption};
+
+    // Note: buffers are kept separate for each OP as the result pointer cannot equal one
+    // of the input pointers.
+    let mut scratch = FieldElement384::<C>::default();
+    let mut acc = FieldElement384::<C>::default();
+    let mut scratch_1 = FieldElement384::<C>::from(x_bytes);
+
+    // x checked to be in the field.
+    C::FieldElement::from_repr(*x_bytes).and_then(|x| {
+        // x * &x * &x
+        scratch_1.mul_unchecked(&scratch_1, &mut scratch);
+        scratch.mul_unchecked(&scratch_1, &mut acc);
+
+        // + &(C::EQUATION_A * &x)
+        scratch_1.mul_unchecked(&C::EQUATION_A_LE, &mut scratch);
+        // Can re-use x as a buffer, no longer needed.
+        scratch.add_unchecked(&acc, &mut scratch_1);
+
+        // + &C::EQUATION_B
+        scratch_1.add_unchecked(&C::EQUATION_B_LE, &mut scratch);
+
+        // Sqrt implementation.
+        scratch.sqrt_unchecked(&mut scratch_1, &mut acc);
+
+        // Check that the square root is correct.
+        acc.square(&mut scratch_1);
+
+        let sqrt = CtOption::new(acc, elliptic_curve::subtle::Choice::from(scratch_1.eq(&scratch) as u8));
+
+        // Checked that the result is within the field.
+        sqrt.and_then(|sqrt| {
+            C::FieldElement::from_repr(sqrt.into()).map(|beta| {
+                let y = C::FieldElement::conditional_select(
+                    &-beta,
+                    &beta,
+                    beta.is_odd().ct_eq(&y_is_odd),
+                );
+
+                AffinePoint { x, y, infinity: 0 }
+            })
+        })
+    })
+}
+
+pub fn affine_to_projective<C>(affine: &ec::AffinePoint<8, C>) -> ProjectivePoint<C>
+where
+    C: PrimeCurveParams256,
 {
     if let Some(value) = affine.as_u32s() {
         // This should only not be within the modulus with a malicious host, panic in that case.
@@ -245,75 +430,391 @@ where
     }
 }
 
-pub(crate) fn scalar_to_words<C>(s: &Scalar<C>) -> [u32; 8]
+pub fn scalar_to_words<C>(s: &Scalar<C>) -> [u32; 8]
 where
-    C: PrimeCurveParams,
+    C: PrimeCurveParams256,
 {
     bytes_to_u32_words_le(s.to_repr().as_slice())
 }
 
-pub(crate) mod ec_impl {
+pub mod ec_impl {
     use super::*;
 
-    pub(crate) fn mul<C>(lhs: &ProjectivePoint<C>, rhs: &Scalar<C>) -> ProjectivePoint<C>
+    pub fn mul<C>(lhs: &ProjectivePoint<C>, rhs: &Scalar<C>) -> ProjectivePoint<C>
     where
-        C: PrimeCurveParams,
+        C: PrimeCurveParams256,
     {
         let scalar = scalar_to_words::<C>(rhs);
         let affine = projective_to_affine::<C>(lhs);
 
-        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
         affine.mul(&scalar, &mut result);
         return affine_to_projective(&result);
     }
 
-    pub(crate) fn add<C>(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    pub fn add<C>(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C>
     where
-        C: PrimeCurveParams,
+        C: PrimeCurveParams256,
     {
         let lhs = projective_to_affine::<C>(lhs);
         let rhs = projective_to_affine::<C>(rhs);
 
-        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
         lhs.add(&rhs, &mut result);
         return affine_to_projective(&result);
     }
 
-    /// Implements complete mixed addition for curves with `a = -3`
-    ///
-    /// Implements the complete mixed addition formula from [Renes-Costello-Batina 2015]
-    /// (Algorithm 5). The comments after each line indicate which algorithm
-    /// steps are being performed.
-    ///
-    /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
     #[inline]
-    pub(crate) fn add_mixed<C>(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C>
+    pub fn add_mixed<C>(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C>
     where
-        C: PrimeCurveParams,
+        C: PrimeCurveParams256,
     {
         let lhs = projective_to_affine::<C>(lhs);
         let rhs = affine_to_r0_affine(rhs);
 
-        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
         lhs.add(&rhs, &mut result);
         return affine_to_projective(&result);
     }
 
-    /// Implements point doubling for curves with `a = -3`
-    ///
-    /// Implements the exception-free point doubling formula from [Renes-Costello-Batina 2015]
-    /// (Algorithm 6). The comments after each line indicate which algorithm
-    /// steps are being performed.
-    ///
-    /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
-    pub(crate) fn double<C>(point: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    pub fn double<C>(point: &ProjectivePoint<C>) -> ProjectivePoint<C>
     where
-        C: PrimeCurveParams,
+        C: PrimeCurveParams256,
     {
         let point = projective_to_affine::<C>(point);
 
-        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
         point.double(&mut result);
         return affine_to_projective(&result);
+    }
+}
+
+// ============================================================================
+// 384-bit curve support
+// ============================================================================
+
+use elliptic_curve::consts::U48;
+
+/// Representation of a 384-bit field element in raw bytes form. This is not in montgomery form.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct FieldElement384<C> {
+    pub data: [u32; 12],
+    _phantom: PhantomData<C>,
+}
+
+impl<C> Deref for FieldElement384<C> {
+    type Target = [u32; 12];
+
+    fn deref(&self) -> &[u32; 12] {
+        &self.data
+    }
+}
+
+impl<C: elliptic_curve::Curve<FieldBytesSize = U48>> From<&FieldBytes<C>> for FieldElement384<C> {
+    fn from(data: &FieldBytes<C>) -> Self {
+        let mut words = [0u32; 12];
+
+        // Process 4 bytes at a time to create little-endian u32 words
+        for (i, chunk) in data.chunks(4).enumerate() {
+            // Convert each big-endian chunk to a little-endian u32
+            words[11 - i] = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+
+        Self::new_unchecked(words)
+    }
+}
+
+impl<C: PrimeCurveParams384> From<FieldElement384<C>> for GenericArray<u8, C::FieldBytesSize> {
+    fn from(data: FieldElement384<C>) -> Self {
+        let bytes_slice = bytemuck::cast_slice::<u32, u8>(&data.data);
+        GenericArray::from_iter(bytes_slice.iter().copied().rev())
+    }
+}
+
+impl<C: Copy> ConditionallySelectable for FieldElement384<C> {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let mut output = *a;
+        output.conditional_assign(b, choice);
+        output
+    }
+
+    fn conditional_assign(&mut self, other: &Self, choice: Choice) {
+        for (a_i, b_i) in self.data.iter_mut().zip(other.data.iter()) {
+            a_i.conditional_assign(b_i, choice)
+        }
+    }
+}
+
+impl<C> FieldElement384<C> {
+    pub const fn new_unchecked(data: [u32; 12]) -> Self {
+        Self {
+            data,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<C> FieldElement384<C>
+where
+    C: PrimeCurveParams384,
+{
+    #[inline]
+    pub fn mul_unchecked(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::unchecked::modmul_384(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    #[inline]
+    pub fn mul(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::modmul_384(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    #[inline]
+    pub fn add_unchecked(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::unchecked::modadd_384(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    /// Calculate the square root of the field element for P-384.
+    /// Uses x^((p+1)/4) since p ≡ 3 (mod 4).
+    /// Based on the addition chain from p384/src/arithmetic/field.rs
+    pub fn sqrt_unchecked(&self, scratch: &mut Self, result: &mut Self) {
+        // We need multiple buffers for intermediate values
+        let mut buf_a = Self::default();
+        let mut buf_b = Self::default();
+        let mut buf_c = Self::default();
+        let mut buf_d = Self::default();
+
+        // t1 = self (input)
+        // t10 = t1^2
+        self.square(&mut buf_a);  // buf_a = t10
+
+        // t11 = t1 * t10 = self^3
+        self.mul_unchecked(&buf_a, &mut buf_b);  // buf_b = t11
+
+        // t110 = t11^2 = self^6
+        buf_b.square(&mut buf_c);  // buf_c = t110
+
+        // t111 = t1 * t110 = self^7
+        self.mul_unchecked(&buf_c, &mut buf_a);  // buf_a = t111
+        let t111 = buf_a;  // save t111
+
+        // t111000 = t111^(2^3) = self^56
+        buf_a.sqn(3, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = t111000
+
+        // t111111 = t111 * t111000 = self^63
+        t111.mul_unchecked(&buf_d, &mut buf_a);  // buf_a = t111111
+        let t111111 = buf_a;  // save t111111
+
+        // t1111110 = t111111^2 = self^126
+        buf_a.square(&mut buf_b);  // buf_b = t1111110
+
+        // t1111111 = t1 * t1111110 = self^127
+        self.mul_unchecked(&buf_b, &mut buf_c);  // buf_c = t1111111
+        let t1111111 = buf_c;  // save t1111111
+
+        // x12 = t1111110^(2^5) * t111111
+        buf_b.sqn(5, (&mut buf_a, &mut buf_d), &mut buf_c);  // buf_c = t1111110^32
+        buf_c.mul_unchecked(&t111111, &mut buf_a);  // buf_a = x12
+        let x12 = buf_a;
+
+        // x24 = x12^(2^12) * x12
+        buf_a.sqn(12, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x12^(2^12)
+        buf_d.mul_unchecked(&x12, &mut buf_a);  // buf_a = x24
+
+        // x31 = x24^(2^7) * t1111111
+        buf_a.sqn(7, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x24^(2^7)
+        buf_d.mul_unchecked(&t1111111, &mut buf_a);  // buf_a = x31
+        let x31 = buf_a;
+
+        // x32 = x31^2 * t1
+        buf_a.square(&mut buf_b);  // buf_b = x31^2
+        self.mul_unchecked(&buf_b, &mut buf_c);  // buf_c = x32
+        let x32 = buf_c;
+
+        // x63 = x32^(2^31) * x31
+        buf_c.sqn(31, (&mut buf_a, &mut buf_b), &mut buf_d);  // buf_d = x32^(2^31)
+        buf_d.mul_unchecked(&x31, &mut buf_a);  // buf_a = x63
+        let x63 = buf_a;
+
+        // x126 = x63^(2^63) * x63
+        buf_a.sqn(63, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x63^(2^63)
+        buf_d.mul_unchecked(&x63, &mut buf_a);  // buf_a = x126
+        let x126 = buf_a;
+
+        // x252 = x126^(2^126) * x126
+        buf_a.sqn(126, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x126^(2^126)
+        buf_d.mul_unchecked(&x126, &mut buf_a);  // buf_a = x252
+
+        // x255 = x252^(2^3) * t111
+        buf_a.sqn(3, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x252^(2^3)
+        buf_d.mul_unchecked(&t111, &mut buf_a);  // buf_a = x255
+
+        // x = ((x255^(2^33) * x32)^(2^64) * t1)^(2^30)
+        buf_a.sqn(33, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = x255^(2^33)
+        buf_d.mul_unchecked(&x32, &mut buf_a);  // buf_a = x255^(2^33) * x32
+        buf_a.sqn(64, (&mut buf_b, &mut buf_c), &mut buf_d);  // buf_d = ...^(2^64)
+        self.mul_unchecked(&buf_d, &mut buf_a);  // buf_a = ... * t1
+        buf_a.sqn(30, (&mut buf_b, &mut buf_c), result);  // result = x
+    }
+
+    /// Returns self^(2^n) mod p.
+    fn sqn(&self, n: usize, scratch: (&mut Self, &mut Self), result: &mut Self) {
+        let mut x = scratch.0;
+        let mut buffer = scratch.1;
+
+        if n == 1 {
+            self.square(result);
+            return;
+        } else if n == 0 {
+            *result = *self;
+            return;
+        }
+
+        self.square(x);
+
+        let mut i = 2;
+        while i < n {
+            x.square(buffer);
+            i += 1;
+            core::mem::swap(&mut x, &mut buffer);
+        }
+
+        x.square(result);
+    }
+
+    /// Returns self^2 mod p
+    pub fn square(&self, result: &mut Self) {
+        self.mul_unchecked(self, result);
+    }
+}
+
+fn bytes_to_u32_words_le_12(bytes: &[u8]) -> [u32; 12] {
+    let mut words = [0u32; 12];
+
+    // Process 4 bytes at a time to create little-endian u32 words
+    for (i, chunk) in bytes.chunks(4).enumerate() {
+        // Convert each big-endian chunk to a little-endian u32
+        words[11 - i] = u32::from_be_bytes(chunk.try_into().unwrap());
+    }
+
+    words
+}
+
+pub fn felt_to_u32_words_le_384<C>(data: &C::FieldElement) -> [u32; 12]
+where
+    C: PrimeCurveParams384,
+{
+    bytes_to_u32_words_le_12(data.to_repr().as_slice())
+}
+
+#[inline]
+fn affine_to_r0_affine_384<C>(affine: &AffinePoint<C>) -> ec::AffinePoint<12, C>
+where
+    C: PrimeCurveParams384,
+{
+    if bool::from(affine.is_identity()) {
+        return ec::AffinePoint::IDENTITY;
+    }
+
+    let x = felt_to_u32_words_le_384::<C>(&affine.x);
+    let y = felt_to_u32_words_le_384::<C>(&affine.y);
+    ec::AffinePoint::new_unchecked(x, y)
+}
+
+pub fn projective_to_affine_384<C>(p: &ProjectivePoint<C>) -> ec::AffinePoint<12, C>
+where
+    C: PrimeCurveParams384,
+{
+    let aff = p.to_affine();
+    affine_to_r0_affine_384(&aff)
+}
+
+pub fn affine_to_projective_384<C>(affine: &ec::AffinePoint<12, C>) -> ProjectivePoint<C>
+where
+    C: PrimeCurveParams384,
+{
+    if let Some(value) = affine.as_u32s() {
+        // This should only not be within the modulus with a malicious host, panic in that case.
+        let x = C::from_u32_words_le(value[0]);
+        let y = C::from_u32_words_le(value[1]);
+
+        let affine = AffinePoint { x, y, infinity: 0 };
+        ProjectivePoint::from(affine)
+    } else {
+        ProjectivePoint::IDENTITY
+    }
+}
+
+pub fn scalar_to_words_384<C>(s: &Scalar<C>) -> [u32; 12]
+where
+    C: PrimeCurveParams384,
+{
+    bytes_to_u32_words_le_12(s.to_repr().as_slice())
+}
+
+pub mod ec_impl_384 {
+    use super::*;
+
+    pub fn mul<C>(lhs: &ProjectivePoint<C>, rhs: &Scalar<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams384,
+    {
+        let scalar = scalar_to_words_384::<C>(rhs);
+        let affine = projective_to_affine_384::<C>(lhs);
+
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 12], [0u32; 12]);
+        affine.mul(&scalar, &mut result);
+        return affine_to_projective_384(&result);
+    }
+
+    pub fn add<C>(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams384,
+    {
+        let lhs = projective_to_affine_384::<C>(lhs);
+        let rhs = projective_to_affine_384::<C>(rhs);
+
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 12], [0u32; 12]);
+        lhs.add(&rhs, &mut result);
+        return affine_to_projective_384(&result);
+    }
+
+    #[inline]
+    pub fn add_mixed<C>(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams384,
+    {
+        let lhs = projective_to_affine_384::<C>(lhs);
+        let rhs = affine_to_r0_affine_384(rhs);
+
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 12], [0u32; 12]);
+        lhs.add(&rhs, &mut result);
+        return affine_to_projective_384(&result);
+    }
+
+    pub fn double<C>(point: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams384,
+    {
+        let point = projective_to_affine_384::<C>(point);
+
+        let mut result = ec::AffinePoint::new_unchecked([0u32; 12], [0u32; 12]);
+        point.double(&mut result);
+        return affine_to_projective_384(&result);
     }
 }

--- a/primeorder/src/risc0.rs
+++ b/primeorder/src/risc0.rs
@@ -76,7 +76,7 @@ where
 {
     #[inline]
     pub fn mul_unchecked(&self, rhs: &Self, result: &mut Self) {
-        risc0_bigint2::field::modmul_256_unchecked(
+        risc0_bigint2::field::unchecked::modmul_256(
             &self.data,
             &rhs.data,
             &C::PRIME_LE_WORDS,
@@ -96,7 +96,7 @@ where
 
     #[inline]
     pub fn add_unchecked(&self, rhs: &Self, result: &mut Self) {
-        risc0_bigint2::field::modadd_256_unchecked(
+        risc0_bigint2::field::unchecked::modadd_256(
             &self.data,
             &rhs.data,
             &C::PRIME_LE_WORDS,

--- a/primeorder/src/risc0.rs
+++ b/primeorder/src/risc0.rs
@@ -1,0 +1,319 @@
+use crate::FieldBytes;
+use crate::{affine::AffinePoint, projective::ProjectivePoint};
+use core::marker::PhantomData;
+use core::ops::Deref;
+use elliptic_curve::consts::U32;
+use elliptic_curve::generic_array::GenericArray;
+use elliptic_curve::subtle::{Choice, ConditionallySelectable};
+use elliptic_curve::{PrimeField, Scalar};
+use risc0_bigint2::ec;
+
+use crate::PrimeCurveParams;
+
+/// Representation of a field element in raw bytes form. This is not in montgomery form.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct FieldElement256<C> {
+    pub data: [u32; 8],
+    _phantom: PhantomData<C>,
+}
+
+impl<C> Deref for FieldElement256<C> {
+    type Target = [u32; 8];
+
+    fn deref(&self) -> &[u32; 8] {
+        &self.data
+    }
+}
+
+impl<C: elliptic_curve::Curve> From<&FieldBytes<C>> for FieldElement256<C> {
+    fn from(data: &FieldBytes<C>) -> Self {
+        let mut words = [0u32; 8];
+
+        // Process 4 bytes at a time to create little-endian u32 words
+        for (i, chunk) in data.chunks(4).enumerate() {
+            // Convert each big-endian chunk to a little-endian u32
+            words[7 - i] = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+
+        Self::new_unchecked(words)
+    }
+}
+
+impl<C: PrimeCurveParams> From<FieldElement256<C>> for GenericArray<u8, C::FieldBytesSize> {
+    fn from(data: FieldElement256<C>) -> Self {
+        let bytes_slice = bytemuck::cast_slice::<u32, u8>(&data.data);
+        GenericArray::from_iter(bytes_slice.iter().copied().rev())
+    }
+}
+
+impl<C: Copy> ConditionallySelectable for FieldElement256<C> {
+    #[inline]
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        let mut output = *a;
+        output.conditional_assign(b, choice);
+        output
+    }
+
+    fn conditional_assign(&mut self, other: &Self, choice: Choice) {
+        for (a_i, b_i) in self.data.iter_mut().zip(other.data.iter()) {
+            a_i.conditional_assign(b_i, choice)
+        }
+    }
+}
+
+impl<C> FieldElement256<C> {
+    pub const fn new_unchecked(data: [u32; 8]) -> Self {
+        Self {
+            data,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<C> FieldElement256<C>
+where
+    C: PrimeCurveParams,
+{
+    #[inline]
+    pub fn mul_unchecked(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::modmul_256_unchecked(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    #[inline]
+    pub fn mul(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::modmul_256(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    #[inline]
+    pub fn add_unchecked(&self, rhs: &Self, result: &mut Self) {
+        risc0_bigint2::field::modadd_256_unchecked(
+            &self.data,
+            &rhs.data,
+            &C::PRIME_LE_WORDS,
+            &mut result.data,
+        );
+    }
+
+    /// Calculate the square root of the field element, using the provided buffer as scratch, and
+    /// writing the result to the `result` parameter.
+    pub(crate) fn sqrt_unchecked(&self, scratch: &mut Self, result: &mut Self) {
+        // New buffers to keep temporary values.
+        let mut scratch_1 = Self::default();
+        let mut scratch_2 = Self::default();
+
+        // let t11 = self.mul(&self.square());
+        self.square(scratch);
+        self.mul_unchecked(scratch, result);
+
+        // result = t11
+        // let t1111 = t11.mul(&t11.sqn(2));
+        result.sqn(2, (&mut scratch_1, &mut scratch_2), scratch);
+        result.mul_unchecked(scratch, &mut scratch_1);
+
+        // scratch_1 = t1111
+        // let t11111111 = t1111.mul(&t1111.sqn(4));
+        scratch_1.sqn(4, (&mut scratch_2, result), scratch);
+        scratch_1.mul_unchecked(scratch, result);
+
+        // result = t11111111
+        // let x16 = t11111111.sqn(8).mul(&t11111111);
+        result.sqn(8, (&mut scratch_1, &mut scratch_2), scratch);
+        result.mul_unchecked(scratch, &mut scratch_1);
+
+        // scratch_1 = x16
+        // let sqrt = x16
+        //     .sqn(16)
+        scratch_1.sqn(16, (&mut scratch_2, result), scratch);
+        //     .mul(&x16)
+        scratch.mul_unchecked(&scratch_1, result);
+        //     .sqn(32)
+        result.sqn(32, (&mut scratch_1, &mut scratch_2), scratch);
+        //     .mul(self)
+        scratch.mul_unchecked(self, &mut scratch_1);
+        //     .sqn(96)
+        scratch_1.sqn(96, (&mut scratch_2, result), scratch);
+        //     .mul(self)
+        scratch.mul_unchecked(self, &mut scratch_2);
+        //     .sqn(94);
+        // Last result is written to the result buffer.
+        scratch_2.sqn(94, (&mut scratch_1, scratch), result);
+    }
+
+    /// Returns self^(2^n) mod p.
+    ///
+    /// This implementation is designed to avoid any memcpy of the buffers for intermediate ops.
+    fn sqn(&self, n: usize, scratch: (&mut Self, &mut Self), result: &mut Self) {
+        let mut x = scratch.0;
+        let mut buffer = scratch.1;
+
+        if n == 1 {
+            // self^(2^1) = self^2
+            self.square(result);
+            return;
+        } else if n == 0 {
+            // self^(1) = self
+            *result = *self;
+            return;
+        }
+
+        // write value to a scratch buffer.
+        self.square(x);
+
+        // Square n - 2 times.
+        let mut i = 2;
+        while i < n {
+            x.square(buffer);
+            i += 1;
+            // Swap scratch buffers, to set x to the squared value.
+            core::mem::swap(&mut x, &mut buffer);
+        }
+
+        // Write final square to result buffer.
+        x.square(result);
+    }
+
+    /// Returns self^2 mod p
+    pub(crate) fn square(&self, result: &mut Self) {
+        self.mul_unchecked(self, result);
+    }
+}
+
+fn bytes_to_u32_words_le(bytes: &[u8]) -> [u32; 8] {
+    let mut words = [0u32; 8];
+
+    // Process 4 bytes at a time to create little-endian u32 words
+    for (i, chunk) in bytes.chunks(4).enumerate() {
+        // Convert each big-endian chunk to a little-endian u32
+        words[7 - i] = u32::from_be_bytes(chunk.try_into().unwrap());
+    }
+
+    words
+}
+
+pub(crate) fn felt_to_u32_words_le<C>(data: &C::FieldElement) -> [u32; 8]
+where
+    C: PrimeCurveParams,
+{
+    bytes_to_u32_words_le(data.to_repr().as_slice())
+}
+
+#[inline]
+fn affine_to_r0_affine<C>(affine: &AffinePoint<C>) -> ec::AffinePoint<8, C>
+where
+    C: PrimeCurveParams,
+{
+    if bool::from(affine.is_identity()) {
+        return ec::AffinePoint::IDENTITY;
+    }
+
+    let x = felt_to_u32_words_le::<C>(&affine.x);
+    let y = felt_to_u32_words_le::<C>(&affine.y);
+    ec::AffinePoint::new_unchecked(x, y)
+}
+
+pub(crate) fn projective_to_affine<C>(p: &ProjectivePoint<C>) -> ec::AffinePoint<8, C>
+where
+    C: PrimeCurveParams,
+{
+    let aff = p.to_affine();
+    affine_to_r0_affine(&aff)
+}
+
+pub(crate) fn affine_to_projective<C>(affine: &ec::AffinePoint<8, C>) -> ProjectivePoint<C>
+where
+    C: PrimeCurveParams,
+{
+    if let Some(value) = affine.as_u32s() {
+        // This should only not be within the modulus with a malicious host, panic in that case.
+        let x = C::from_u32_words_le(value[0]);
+        let y = C::from_u32_words_le(value[1]);
+
+        let affine = AffinePoint { x, y, infinity: 0 };
+        ProjectivePoint::from(affine)
+    } else {
+        ProjectivePoint::IDENTITY
+    }
+}
+
+pub(crate) fn scalar_to_words<C>(s: &Scalar<C>) -> [u32; 8]
+where
+    C: PrimeCurveParams,
+{
+    bytes_to_u32_words_le(s.to_repr().as_slice())
+}
+
+pub(crate) mod ec_impl {
+    use super::*;
+
+    pub(crate) fn mul<C>(lhs: &ProjectivePoint<C>, rhs: &Scalar<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams,
+    {
+        let scalar = scalar_to_words::<C>(rhs);
+        let affine = projective_to_affine::<C>(lhs);
+
+        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        affine.mul(&scalar, &mut result);
+        return affine_to_projective(&result);
+    }
+
+    pub(crate) fn add<C>(lhs: &ProjectivePoint<C>, rhs: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams,
+    {
+        let lhs = projective_to_affine::<C>(lhs);
+        let rhs = projective_to_affine::<C>(rhs);
+
+        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        lhs.add(&rhs, &mut result);
+        return affine_to_projective(&result);
+    }
+
+    /// Implements complete mixed addition for curves with `a = -3`
+    ///
+    /// Implements the complete mixed addition formula from [Renes-Costello-Batina 2015]
+    /// (Algorithm 5). The comments after each line indicate which algorithm
+    /// steps are being performed.
+    ///
+    /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
+    #[inline]
+    pub(crate) fn add_mixed<C>(lhs: &ProjectivePoint<C>, rhs: &AffinePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams,
+    {
+        let lhs = projective_to_affine::<C>(lhs);
+        let rhs = affine_to_r0_affine(rhs);
+
+        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        lhs.add(&rhs, &mut result);
+        return affine_to_projective(&result);
+    }
+
+    /// Implements point doubling for curves with `a = -3`
+    ///
+    /// Implements the exception-free point doubling formula from [Renes-Costello-Batina 2015]
+    /// (Algorithm 6). The comments after each line indicate which algorithm
+    /// steps are being performed.
+    ///
+    /// [Renes-Costello-Batina 2015]: https://eprint.iacr.org/2015/1060
+    pub(crate) fn double<C>(point: &ProjectivePoint<C>) -> ProjectivePoint<C>
+    where
+        C: PrimeCurveParams,
+    {
+        let point = projective_to_affine::<C>(point);
+
+        let mut result = risc0_bigint2::ec::AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+        point.double(&mut result);
+        return affine_to_projective(&result);
+    }
+}


### PR DESCRIPTION
I needed fast p384 support in a circuit and noticed risc0-bigint2 already had support for it.

 You can view my commit at: https://github.com/risc0/RustCrypto-elliptic-curves/commit/b29e27fe3a23c9aec0b6afe06011474d54411070

I've implemented the same approach as p256 from #10, and I believe this should close #14 as I've covered:

 > 'I think at some point, it would be ideal to implement primeorder::risc0 generically, rather than fixing the width of field element to a specific length.

Isolated ECDSA signature verification (single operation) 'benchmark' with code in this PR:

- P-256: 244,814 cycles (somehow we gained 113 cycles?)
- P-384: 509,033 cycles

With current code:
 - P-256: 244,701 cycles 
 - P-384: 62,695,757 cycles

Please advise on the workflow, you appear to be using tags rather than branches, and I'm not familiar with your release process. 